### PR TITLE
Modify test to accomodate output

### DIFF
--- a/test/testSuites/testSuite_check_maxrss.sh
+++ b/test/testSuites/testSuite_check_maxrss.sh
@@ -74,11 +74,19 @@ test_check_maxrss() {
              return
         fi
 
-        newVal=`grep Max.Resident.Set $outFile | awk '{print $7}'`
+# New Bailing Wire October 2015
+#    Output format different with multiple threads
+        LINE2TEST=`grep Max.Resident.Set $outFile`
+        WANTEDLINE=`echo $LINE2TEST | sed s/'.*SST Core/SST Core'/`
+echo LINE2TEST  $LINE2TEST
+echo WANTEDLINE= $WANTEDLINE
+##      newVal=`grep Max.Resident.Set $outFile | awk '{print $7}'`
+        newVal=`echo $WANTEDLINE | awk '{print $7}'`
 #     Bailing wire to support enhanced format of verbose
 #         For bash to do simple compare original KB units were convenient.
 #            Convert MB to KB.
-        MB=`grep Max.Resident.Set $outFile | awk '{print $8}'`
+#       MB=`grep Max.Resident.Set $outFile | awk '{print $8}'`
+        MB=`echo $WANTEDLINE | awk '{print $8}'`
         if [ $MB == "MB" ] ; then
            newVal="$(echo "$newVal*1000" | bc)"
            newVal=`echo $newVal | awk -F. '{print $1}'`


### PR DESCRIPTION
Verbose output varies depending on whether more than one thread is requested.