### PR TITLE
BadPort: Remove stdout buffering.

### DIFF
--- a/test/testSuites/testSuite_BadPort.sh
+++ b/test/testSuites/testSuite_BadPort.sh
@@ -71,7 +71,8 @@ test_BadPort() {
     if [ -f ${sut} ] && [ -x ${sut} ]
     then
         # Run SUT
-        ${sut} ${sutArgs} > $outFile 2>$errFile
+        # Because we expect a segfault, turn of stdout buffering so we get the full output
+        stdbuf -o0 -e0 ${sut} ${sutArgs} > $outFile 2>$errFile
         retval=$?
 
         if [ $retval != 0 ]


### PR DESCRIPTION
When the test depends on a segfault, you cannot depend on stdout being
properly flushed.  Prepend call to ${sut} with 'stdbuf -o0 -e0' to turn
off stdout and stderr file buffering.