### PR TITLE
Don't Run Scheduler Test 6 on MacOS for now

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -408,8 +408,9 @@ echo " #####################################################"
     ${SST_TEST_SUITES}/testSuite_miranda.sh
     ${SST_TEST_SUITES}/testSuite_BadPort.sh
     ${SST_TEST_SUITES}/testSuite_scheduler.sh
-    ${SST_TEST_SUITES}/testSuite_scheduler_DetailedNetwork.sh
-
+    if [ $kernel != "Darwin" ] ; then
+         ${SST_TEST_SUITES}/testSuite_scheduler_DetailedNetwork.sh
+    fi 
     # Add other test suites here, i.e.
     # ${SST_TEST_SUITES}/testSuite_moe.sh
     # ${SST_TEST_SUITES}/testSuite_larry.sh


### PR DESCRIPTION
It enters an infinite loop that time-limit processing doesn't terminate.