### PR TITLE
This reverts commit a962ad1828b90acbd53e1ac464fca1a7e72c55d7.

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -408,9 +408,8 @@ echo " #####################################################"
     ${SST_TEST_SUITES}/testSuite_miranda.sh
     ${SST_TEST_SUITES}/testSuite_BadPort.sh
     ${SST_TEST_SUITES}/testSuite_scheduler.sh
-    if [ $kernel != "Darwin" ] ; then
-         ${SST_TEST_SUITES}/testSuite_scheduler_DetailedNetwork.sh
-    fi 
+    ${SST_TEST_SUITES}/testSuite_scheduler_DetailedNetwork.sh
+
     # Add other test suites here, i.e.
     # ${SST_TEST_SUITES}/testSuite_moe.sh
     # ${SST_TEST_SUITES}/testSuite_larry.sh


### PR DESCRIPTION
Re-enable Scheduler test 6 on MacOS