### PR TITLE
Omit scheduler test 6 also if n>1

### DIFF
--- a/test/testSuites/testSuite_scheduler_DetailedNetwork.sh
+++ b/test/testSuites/testSuite_scheduler_DetailedNetwork.sh
@@ -26,6 +26,13 @@ L_SUITENAME="scheduler_DetailedNetwork_suite" # Name of this test suite; will be
 
 L_TESTFILE=()  # Empty list, used to hold test file names
 
+    if [[ ${SST_MULTI_THREAD_COUNT:+isSet} == isSet ]] ; then
+       if [ $SST_MULTI_THREAD_COUNT -gt 1 ] ; then
+           echo '           SKIP '
+           preFail " Scheduler tests do not work with threading" "skip"
+       fi
+    fi     
+
 #===============================================================================
 # Test functions
 #   NOTE: These functions are invoked automatically by shunit2 as long


### PR DESCRIPTION
Scheduler is reported to be known to be not thread-safe 