### PR TITLE
Add support to build on Ubuntu 16.04

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1081,6 +1081,11 @@ linuxSetBoostMPI() {
            ModuleEx unload mpi # unload any default to avoid conflict error
            ModuleEx load mpi/${desiredMPI}
            ;;
+       openmpi-1.6.5)
+           echo "OpenMPI (openmpi-1.6.5) selected"
+           ModuleEx unload mpi # unload any default to avoid conflict error
+           ModuleEx load mpi/${desiredMPI}
+           ;;
        openmpi-1.8)
            echo "OpenMPI (openmpi-1.8) selected"
            ModuleEx unload mpi # unload any default to avoid conflict error
@@ -1174,7 +1179,8 @@ linuxSetBoostMPI() {
    then
        # GNU Linear Programming Kit (GLPK)
        echo "bamboo.sh: Load GLPK"
-       ModuleEx load glpk/glpk-4.54
+       # Load available GLPK, whatever version it is
+       ModuleEx load glpk
        # System C
 #       echo "bamboo.sh: Load System C"
 #       ModuleEx load systemc/systemc-2.3.0


### PR DESCRIPTION
Load modulefile for OpenMPI 1.6.5 (bundled with Ubuntu 16.04).  Also change loading of GLPK to load default version (version bundled with Ubuntu 16.04B) instead of explicit version 4.54.