### PR TITLE
Adjust bamboo.sh for OpenMPI 1.10 on COE RHEL 7

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1091,6 +1091,11 @@ linuxSetBoostMPI() {
            ModuleEx unload mpi # unload any default to avoid conflict error
            ModuleEx load mpi/${desiredMPI}
            ;;
+        openmpi-1.10)
+           echo "OpenMPI (openmpi-1.10) selected"
+           ModuleEx unload mpi # unload any default to avoid conflict error
+           ModuleEx load mpi/${desiredMPI}
+           ;;
        none)
            echo "MPI requested as \"none\".    No MPI loaded"
            ModuleEx unload mpi # unload any default 


### PR DESCRIPTION
Add support for bundled OpenMPI 10.10 on Sandie COE RHEL 7