### PR TITLE
Add Ubuntu 16.06 specific module init code.

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1072,22 +1072,15 @@ linuxSetBoostMPI() {
    # For some reason, .bashrc is not being run prior to
    # this script. Kludge initialization of modules.
 
-echo ' '
-echo " This is linuxSetBoostMPI"
    if [ $SST_TEST_HOST_OS_DISTRIB_VERSION != "16.04" ] ; then
-echo " TEMP DEBUG   this is not U 16.04"
-       if [ -f /etc/profile.modules ]
-       then
+       if [ -f /etc/profile.modules ] ; then
            . /etc/profile.modules
            echo "bamboo.sh: loaded /etc/profile.modules. Available modules"
            ModuleEx avail
        fi
    else
-echo " TEMP DEBUG   This is U 16.04"
-ls -l /etc/profile.d/modules.sh
-ls -l /etc/profile.d
-       if [ -r /etc/profile.d/modules.sh ] 
-       then 
+       ls -l /etc/profile.d/modules.sh
+       if [ -r /etc/profile.d/modules.sh ] ; then 
            source /etc/profile.d/modules.sh 
            echo " bamboo.sh:  Available modules"
            ModuleEx avail

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1086,11 +1086,15 @@ echo " TEMP DEBUG   this is not U 16.04"
 echo " TEMP DEBUG   This is U 16.04"
 ls -l /etc/profile.d/modules.sh
 ls -l /etc/profile.d
-       if [ -x /etc/profile.d/modules.sh ] 
+       if [ -r /etc/profile.d/modules.sh ] 
        then 
            source /etc/profile.d/modules.sh 
            echo " bamboo.sh:  Available modules"
            ModuleEx avail
+           if [ $? -ne 0 ] ; then
+               echo " ModuleEx Failed"
+               exit 1
+           fi    
        fi
    fi
 

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1084,7 +1084,9 @@ i  else
 echo " TEMP DEBUG   This is U 16.04"
        if [ -x /etc/profile.d/modules.sh ] 
        then 
-       source /etc/profile.d/modules.sh  
+           source /etc/profile.d/modules.sh 
+           echo " bamboo.sh:  Available modules"
+           ModuleEx avail
        fi
    fi
 

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1080,7 +1080,7 @@ echo " TEMP DEBUG   this is not U 16.04"
            echo "bamboo.sh: loaded /etc/profile.modules. Available modules"
            ModuleEx avail
        fi
-i  else
+   else
 echo " TEMP DEBUG   This is U 16.04"
        if [ -x /etc/profile.d/modules.sh ] 
        then 

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1084,6 +1084,8 @@ echo " TEMP DEBUG   this is not U 16.04"
        fi
    else
 echo " TEMP DEBUG   This is U 16.04"
+ls -l /etc/profile.d/modules.sh
+ls -l /etc/profile.d
        if [ -x /etc/profile.d/modules.sh ] 
        then 
            source /etc/profile.d/modules.sh 

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1071,13 +1071,22 @@ linuxSetBoostMPI() {
 
    # For some reason, .bashrc is not being run prior to
    # this script. Kludge initialization of modules.
-   if [ -f /etc/profile.modules ]
-   then
-       . /etc/profile.modules
-       echo "bamboo.sh: loaded /etc/profile.modules. Available modules"
-       ModuleEx avail
-   fi
 
+   if [ $SST_TEST_HOST_OS_DISTRIB_VERSION != "16.04" ] ; then
+echo " TEMP DEBUG   this is not U 16.04"
+       if [ -f /etc/profile.modules ]
+       then
+           . /etc/profile.modules
+           echo "bamboo.sh: loaded /etc/profile.modules. Available modules"
+           ModuleEx avail
+       fi
+i  else
+echo " TEMP DEBUG   This is U 16.04"
+       if [ -x /etc/profile.d/modules.sh ] 
+       then 
+       source /etc/profile.d/modules.sh  
+       fi
+   fi
 
    # build MPI and Boost selectors
    if [[ "$2" =~ openmpi.* ]]

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1072,6 +1072,8 @@ linuxSetBoostMPI() {
    # For some reason, .bashrc is not being run prior to
    # this script. Kludge initialization of modules.
 
+echo ' '
+echo " This is linuxSetBoostMPI"
    if [ $SST_TEST_HOST_OS_DISTRIB_VERSION != "16.04" ] ; then
 echo " TEMP DEBUG   this is not U 16.04"
        if [ -f /etc/profile.modules ]


### PR DESCRIPTION
Ubuntu 16.04 is still pre-release and changing.   Jon filed a bug report with Ubuntu about the need for this kludge.   So things may change