### PR TITLE
Revert "Skip memHS test if Ariel dot-h file is not found"

### DIFF
--- a/test/testSuites/testSuite_memHSieve.sh
+++ b/test/testSuites/testSuite_memHSieve.sh
@@ -36,16 +36,14 @@ L_TESTFILE=()  # Empty list, used to hold test file names
 #   NOTE: These functions are invoked automatically by shunit2 as long
 #   as the function name begins with "test...".
 #===============================================================================
-if [[ ! -e $SST_ROOT/sst-elements/src/sst/elements/ariel/arielalloctrackev.h ]] ; then
+if [[ ! -s $SST_BASE/local/sst-elements/lib/sst-elements-library/libariel.so ]] ; then
     preFail "Skipping memHSieve, (no Ariel )"  "skip"
-else
-     echo "Found the Ariel file! "
 fi
-## if [[ `uname -n` != sst-test* ]] ; then
-##     echo " "
-##     echo "libariel.so test is INADEQUATE!   "
-##     preFail "Only running on sst-test at this time" "skip"
-## fi
+if [[ `uname -n` != sst-test* ]] ; then
+    echo " "
+    echo "libariel.so test is INADEQUATE!   "
+    preFail "Only running on sst-test at this time" "skip"
+fi
 
 #-------------------------------------------------------------------------------
 # Test:


### PR DESCRIPTION
This reverts commit 2c85bb6a205795723a94b36074d1cd13ee4403fd.