### PR TITLE
Qsim patch elements

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -911,7 +911,7 @@ getconfig() {
             export | egrep SST_DEPS_
             coreMiscEnv="${cc_environment} ${mpi_environment}"
             elementsMiscEnv="${cc_environment}"
-            depsStr="-k none -d 2.2.2 -p none -b 1.50 -g none -m none -i none -o none -h none -s none -q none -M none -N default -z 3.83 -c default"
+            depsStr="-k none -d 2.2.2 -p none -b 1.50 -g none -m none -i none -o none -h none -s none -q 0.2.1 -M none -N default -z 3.83 -c default"
             setConvenienceVars "$depsStr"
             coreConfigStr="$corebaseoptions --with-zoltan=$SST_DEPS_INSTALL_ZOLTAN $coreMiscEnv"
             elementsConfigStr="$elementsbaseoptions --with-dramsim=$SST_DEPS_INSTALL_DRAMSIM --with-nvdimmsim=$SST_DEPS_INSTALL_NVDIMMSIM --with-hybridsim=$SST_DEPS_INSTALL_HYBRIDSIM --with-qsim=$SST_DEPS_INSTALL_QSIM --with-glpk=${GLPK_HOME} --with-metis=${METIS_HOME} --with-chdl=$SST_DEPS_INSTALL_CHDL $elementsMiscEnv --with-pin=$SST_DEPS_INSTALL_INTEL_PIN"

--- a/buildsys/deps/bin/sstDep_qsim_0.2.1.sh
+++ b/buildsys/deps/bin/sstDep_qsim_0.2.1.sh
@@ -133,7 +133,7 @@ sstDepsDeploy_qsim ()
     # Apply patch for file open problem
     echo "INFO: (${FUNCNAME})  Patching qsim-0.2.1/mgzd.h..."
 
-    patch -i ${SST_DEPS_PATCHFILES}/qsim-0.2.1-fileOpenCheck.patch
+    patch -i ${SST_ROOT}/sst-elements/src/sst/elements/qsimComponent/patches/qsim-0.2.1-fileOpenCheck.patch
 
     if [ $? -ne 0 ] ; then
        echo ' ' ; echo "  PATCH FAILED"


### PR DESCRIPTION
Enable Qsim and in preparation for release, use the patch from element/qsimComponent, rather than SQE