### PR TITLE
Per Issue 129, omit mit McOpreron test2

### DIFF
--- a/test/testSuites/testSuite_sst_mcopteron.sh
+++ b/test/testSuites/testSuite_sst_mcopteron.sh
@@ -188,7 +188,7 @@ echo "\$lout is $lout ############################################"
     echo "mcopteron test1: Wall Clock Time  $elapsedSeconds seconds"
 }
 
-test_sst_mcopteron_test2() {
+XXtest_sst_mcopteron_test2() {
      echo ' '
      echo "Test 2  universally disabled February 22, 2016"
      echo ' '


### PR DESCRIPTION
As Issue 129 said on February 22, omit McOperon test2