### PR TITLE
Update testSuite_memHSieve.sh

### DIFF
--- a/test/testSuites/testSuite_memHSieve.sh
+++ b/test/testSuites/testSuite_memHSieve.sh
@@ -205,7 +205,7 @@ ls -ltr
     fi
     popd
 }
-export SST_TEST_ONE_TEST_TIMEOUT=30
+export SST_TEST_ONE_TEST_TIMEOUT=50
 export SHUNIT_OUTPUTDIR=$SST_TEST_RESULTS
 
 


### PR DESCRIPTION
Increase allowed wall clock time for memHSieve.   30 seconds was right on the edge for Yosemite VM