### PR TITLE
improve module utility init code

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1263,24 +1263,28 @@ linuxSetBoostMPI() {
    # For some reason, .bashrc is not being run prior to
    # this script. Kludge initialization of modules.
 
-   if [ $SST_TEST_HOST_OS_DISTRIB_VERSION != "16.04" ] ; then
-       if [ -f /etc/profile.modules ] ; then
-           . /etc/profile.modules
-           echo "bamboo.sh: loaded /etc/profile.modules. Available modules"
-           ModuleEx avail
-       fi
-   else
-       ls -l /etc/profile.d/modules.sh
-       if [ -r /etc/profile.d/modules.sh ] ; then 
-           source /etc/profile.d/modules.sh 
-           echo " bamboo.sh:  Available modules"
-           ModuleEx avail
-           if [ $? -ne 0 ] ; then
-               echo " ModuleEx Failed"
-               exit 1
-           fi    
-       fi
+   echo "Attempt to initialize the modules utility.  Look for modules init file in 1 of 2 places"
+   
+   echo "Location 1: ls -l /etc/profile.modules.sh"
+   ls -l /etc/profile.modules.sh
+   if [ -f /etc/profile.modules ] ; then
+       . /etc/profile.modules
+       echo "bamboo.sh: loaded /etc/profile.modules."
    fi
+   
+   echo "Location 2: ls -l /etc/profile.d/modules.sh"
+   ls -l /etc/profile.d/modules.sh
+   if [ -r /etc/profile.d/modules.sh ] ; then 
+       source /etc/profile.d/modules.sh 
+       echo "bamboo.sh: loaded /etc/profile.d/modules."
+   fi
+   
+   echo "Testing modules utility via ModuleEx..."
+   ModuleEx avail
+   if [ $? -ne 0 ] ; then
+       echo " ModuleEx Failed"
+       exit 1
+   fi    
 
    # build MPI and Boost selectors
    if [[ "$2" =~ openmpi.* ]]

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1280,6 +1280,7 @@ linuxSetBoostMPI() {
    fi
    
    echo "Testing modules utility via ModuleEx..."
+   echo "ModuleEx avail"
    ModuleEx avail
    if [ $? -ne 0 ] ; then
        echo " ModuleEx Failed"

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1265,18 +1265,18 @@ linuxSetBoostMPI() {
 
    echo "Attempt to initialize the modules utility.  Look for modules init file in 1 of 2 places"
    
-   echo "Location 1: ls -l /etc/profile.modules.sh"
-   ls -l /etc/profile.modules.sh
+   echo "Location 1: ls -l /etc/profile.modules"
+   ls -l /etc/profile.modules
    if [ -f /etc/profile.modules ] ; then
        . /etc/profile.modules
-       echo "bamboo.sh: loaded /etc/profile.modules."
-   fi
-   
-   echo "Location 2: ls -l /etc/profile.d/modules.sh"
-   ls -l /etc/profile.d/modules.sh
-   if [ -r /etc/profile.d/modules.sh ] ; then 
-       source /etc/profile.d/modules.sh 
-       echo "bamboo.sh: loaded /etc/profile.d/modules."
+       echo "bamboo.sh: loaded /etc/profile.modules"
+   else
+       echo "Location 2: ls -l /etc/profile.d/modules.sh"
+       ls -l /etc/profile.d/modules.sh
+       if [ -r /etc/profile.d/modules.sh ] ; then 
+           source /etc/profile.d/modules.sh 
+           echo "bamboo.sh: loaded /etc/profile.d/modules"
+       fi
    fi
    
    echo "Testing modules utility via ModuleEx..."


### PR DESCRIPTION
Changed the init code for Linux platforms to try 1 of 2 different methods to initialize the module utility.  Afterwards, it tries to perform a module avail via the ModuleEx wrapper.  This should fix the issue with Ubuntu 14.04 failing Since the new Jenkins upgrade.