### PR TITLE
Reduce warning from MacOS 

### DIFF
--- a/test/testSuites/testSuite_embernightly.sh
+++ b/test/testSuites/testSuite_embernightly.sh
@@ -32,7 +32,9 @@ L_BUILDTYPE=$1 # Build type, passed in from bamboo.sh as a convenience
 L_TESTFILE=()  # Empty list, used to hold test file names
 
 #=====================================================
+if [ $SST_TEST_HOST_OS_KERNEL != "Darwin" ] ; then
 #  A bit of code to clear out old openmpi files from /tmp
+#   --This is Linux code and MacOS can't handle this date syntax--
 
     ls -ld /tmp/openmpi-sessions*/* |grep $USER > __rmlist
     wc __rmlist
@@ -51,6 +53,7 @@ L_TESTFILE=()  # Empty list, used to hold test file names
     
     done 3<__rmlist
     rm __rmlist
+fi
 #=====================================================
 
 #===============================================================================

--- a/test/testSuites/testSuite_embernightly.sh
+++ b/test/testSuites/testSuite_embernightly.sh
@@ -32,14 +32,14 @@ L_BUILDTYPE=$1 # Build type, passed in from bamboo.sh as a convenience
 L_TESTFILE=()  # Empty list, used to hold test file names
 
 #=====================================================
-if [ $SST_TEST_HOST_OS_KERNEL != "Darwin" ] ; then
 #  A bit of code to clear out old openmpi files from /tmp
-#   --This is Linux code and MacOS can't handle this date syntax--
 
     ls -ld /tmp/openmpi-sessions*/* |grep $USER > __rmlist
     wc __rmlist
     today=$(( 10#`date +%j` ))
     echo "today is $today"
+if [ $SST_TEST_HOST_OS_KERNEL != "Darwin" ] ; then
+#   --This is Linux code and MacOS can't handle this date syntax--
     
     while read -u 3 r1 r2 r3 r4 r5 mo da r8 name
     do
@@ -52,8 +52,8 @@ if [ $SST_TEST_HOST_OS_KERNEL != "Darwin" ] ; then
       fi
     
     done 3<__rmlist
-    rm __rmlist
 fi
+    rm __rmlist
 #=====================================================
 
 #===============================================================================


### PR DESCRIPTION
This test clean-up code code doesn't work on MacOS.  Don't complain about the test failure for pages and pages.