### PR TITLE
Better mpi chk

### DIFF
--- a/test/include/testSubroutines.sh
+++ b/test/include/testSubroutines.sh
@@ -310,7 +310,6 @@ RemoveComponentWarning() {
 # ----------------------------------------------------
 checkValgrindOutput() {
 VGout=$1        #the Valgrind output file
-MPIerrors=$2
 grep ERROR.SUMMARY $VGout  > /dev/null
 if [ $? != 0 ] ; then 
     echo "Valgrind Summary not found"
@@ -324,10 +323,17 @@ fi
 ###  ------
     grep ERROR.SUMMARY $VGout | sed s/ERROR//
 contextNumber=`grep ERROR.SUMMARY $VGout | awk '{print $7}'`
-if [ $contextNumber -gt $MPIerrors ] ; then
+if [ $contextNumber -gt 0 ] ; then
+    sed -n '/ Invalid.read.of.size.4/{N;p;q}' $VGout  | grep opal_os_dirpath_create > /dev/null
+    if [ $? == 0 ] ;then
+        contextNumber=$(($contextNumber-1))
+        echo "Ignoring MPI Invalid read of size 4"
+    fi
+fi
+if [ $contextNumber -gt 0 ] ; then
     echo ' '
-    echo "Valgrind found issues"
-    fail " $testDataFileBase: Valgind found $((contextNumber - MPIerrors)) issues"
+    echo "Valgrind found $contextNumber issues"
+    fail " $testDataFileBase: Valgind found $contextNumber issues"
     echo ' '
 else
     echo ' '

--- a/test/include/testSubroutines.sh
+++ b/test/include/testSubroutines.sh
@@ -327,7 +327,7 @@ if [ $contextNumber -gt 0 ] ; then
     sed -n '/ Invalid.read.of.size.4/{N;p;q}' $VGout  | grep opal_os_dirpath_create > /dev/null
     if [ $? == 0 ] ;then
         contextNumber=$(($contextNumber-1))
-        echo "Ignoring MPI Invalid read of size 4"
+        echo "Ignoring MPI \"Invalid read of size 4\""
     fi
 fi
 if [ $contextNumber -gt 0 ] ; then


### PR DESCRIPTION
Verify that the Valgrind error is from the expected openmpi error, before simply ignoring one error.