### PR TITLE
Remove "exit" from test Suite

### DIFF
--- a/test/testSuites/testSuite_CramSim.sh
+++ b/test/testSuites/testSuite_CramSim.sh
@@ -49,15 +49,14 @@ ln -s $SST_ROOT/sst-elements/src/sst/elements/CramSim/ddr4_verimem.cfg .
 ls -l $SST_ROOT/sst-elements/src/sst/elements/CramSim/ddr4_verimem.cfg  > /dev/null
 if [ $? != 0 ] ; then
    ls $SST_ROOT/sst-elements/src/sst/elements/CramSim
-   exit
+   preFail "Can't find/access ddr4_verimem.cfg from sst-elements"
 fi
 mkdir tests
 
 ln -s $SST_ROOT/sst-elements/src/sst/elements/CramSim/tests/* tests
 ls -l ddr4_verimem.cfg
 if [ $? != 0 ] ; then
-   echo "############################################## $LINENO "
-   exit
+   preFail "Can't find ddr4_verimem.cfg in SQE CramSim directory"
 fi
 cd tests
 


### PR DESCRIPTION
"exit" command in test Suite results in silent failure.