### PR TITLE
Update testSuite_partitioner.sh removing "--run-mode init"

### DIFF
--- a/test/testSuites/testSuite_partitioner.sh
+++ b/test/testSuites/testSuite_partitioner.sh
@@ -177,7 +177,7 @@ PARTITIONER=$2
     if [ -f ${sut} ] && [ -x ${sut} ]
     then
         # Run SUT
-        mpirun -np ${NUMRANKS} ${sut} --verbose --run-mode init --partitioner $PARTITIONER --output-partition $partFile --model-options "--topo=torus --shape=4x4x4 --cmdLine=\"Init\" --cmdLine=\"Allreduce\" --cmdLine=\"Fini\"" ${sutArgs} > $outFile 2>$errFile
+        mpirun -np ${NUMRANKS} ${sut} --verbose --partitioner $PARTITIONER --output-partition $partFile --model-options "--topo=torus --shape=4x4x4 --cmdLine=\"Init\" --cmdLine=\"Allreduce\" --cmdLine=\"Fini\"" ${sutArgs} > $outFile 2>$errFile
         RetVal=$?
         TIME_FLAG=/tmp/TimeFlag_$$_${__timerChild} 
         if [ -e $TIME_FLAG ] ; then 


### PR DESCRIPTION
This flag was inserted (long ago) in response to core issue 21.

Verification that it was not longer need occurred on January 4th.  This removes it from the test Suite in SQE

