### PR TITLE
No Write to Elements subtree by SQE test

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -228,6 +228,7 @@ dotests() {
        echo "     ENFORCING no write to elements by SQE tests"
        echo ' '
        echo "#################################################### "
+       chmod -w -R $SST_ROOT/sst-elements/src/sst/elements
    fi
    echo "bamboo.sh: This directory is:"
    pwd

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -222,6 +222,13 @@ dotests() {
     #  If it is Intel, Need a GCC library also
     #    Going to load the gcc-4.8.1 module for now
 
+   if [[ ${SST_TEST_WITH_NO_ELEMENTS_WRITE:+isSet} == isSet ]] ; then
+       echo "#################################################### "
+       echo ' '
+       echo "     ENFORCING no write to elements by SQE tests"
+       echo ' '
+       echo "#################################################### "
+   fi
    echo "bamboo.sh: This directory is:"
    pwd
    echo "bamboo.sh: ls test/include"

--- a/test/testSuites/testSuite_Ariel.sh
+++ b/test/testSuites/testSuite_Ariel.sh
@@ -106,7 +106,7 @@ ls -l
 #          This could be in subroutine library - for now only Ariel
 removeFreeIPCs() {
     #   Find and kill orphanned running binaries
-    ps -f > _running_bin
+    ps -f > ${SSTTESTTEMPFILES}/_running_bin
     while read -u 3 uid pid ppid p4 p5 p6 p7 cmd
     do
 ##        echo "          DEBUG ONLY $uid $pid $ppid $cmd"
@@ -118,11 +118,11 @@ removeFreeIPCs() {
                echo " Omitting kill of $uid $ppid $cmd"
            fi
         fi
-    done 3<_running_bin
+    done 3<${SSTTESTTEMPFILES}/_running_bin
   
     #  Find and remove no longer attached shared memory segments  
-    ipcs > _ipc_list
-    ##     echo "         DEBUG ONLY `wc _ipc_list`"
+    ipcs > ${SSTTESTTEMPFILES}/_ipc_list
+    ##     echo "         DEBUG ONLY `wc ${SSTTESTTEMPFILES}/_ipc_list`"
     while read -u 3 key shmid own perm size n_att rest
     do
          if [[ $key == "" ]] || [[ $n_att == "" ]] ; then
@@ -133,8 +133,8 @@ removeFreeIPCs() {
           echo " Removing an idle Shared Mem allocation"
           ipcrm -m $shmid
        fi
-    done 3<_ipc_list
-    rm _ipc_list  _running_bin
+    done 3<${SSTTESTTEMPFILES}/_ipc_list
+    rm ${SSTTESTTEMPFILES}/_ipc_list  ${SSTTESTTEMPFILES}/_running_bin
 }
 
 #-------------------------------------------------------------------------------

--- a/test/testSuites/testSuite_EmberSweep.sh
+++ b/test/testSuites/testSuite_EmberSweep.sh
@@ -83,16 +83,12 @@ L_TESTFILE=()  # Empty list, used to hold test file names
     #  Most test Suites explicitly define an environment variable sut to be full path SST
     #     The Python script does not do this
 
-pwd
 
-###--- pushd ${SST_ROOT}/sst-elements/src/sst/elements/ember/test
     mkdir ${SST_TEST_SUITES}/emberSweep_folder
     pushd ${SST_TEST_SUITES}/emberSweep_folder
     cp ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/* .
     chmod +w *
 
-pwd
-ls
 #      Initialize variables
 startSeconds=0
 RUNNING_INDEX=0
@@ -117,7 +113,6 @@ SE_start() {
     testDataFileBase="testES_${TEST_INDEX}"
     L_TESTFILE+=(${testDataFileBase})
 #             For Valgrind, sut= will be installed after this line.
-###---    pushd ${SST_ROOT}/sst-elements/src/sst/elements/ember/test
     pushd ${SST_TEST_SUITES}/emberSweep_folder
 }   
 ####################
@@ -165,7 +160,6 @@ SE_fini() {
        echo ' '
        grep Ember_${1} -A 5 ${SSTTESTTEMPFILES}/bashIN | grep sst
        echo ' '
-###---       wc ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/tmp_file
        wc tmp_file
        len_tmp_file=`wc -l ./tmp_file | awk '{print $1}'`
        if [ $len_tmp_file -gt 25 ] ; then

--- a/test/testSuites/testSuite_EmberSweep.sh
+++ b/test/testSuites/testSuite_EmberSweep.sh
@@ -85,7 +85,11 @@ L_TESTFILE=()  # Empty list, used to hold test file names
 
 pwd
 
-pushd ${SST_ROOT}/sst-elements/src/sst/elements/ember/test
+###--- pushd ${SST_ROOT}/sst-elements/src/sst/elements/ember/test
+    mkdir ${SST_TEST_SUITES}/emberSweep_folder
+    pushd ${SST_TEST_SUITES}/emberSweep_folder
+    cp ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/* .
+    chmod +w *
 
 pwd
 ls
@@ -113,8 +117,9 @@ SE_start() {
     testDataFileBase="testES_${TEST_INDEX}"
     L_TESTFILE+=(${testDataFileBase})
 #             For Valgrind, sut= will be installed after this line.
-    pushd ${SST_ROOT}/sst-elements/src/sst/elements/ember/test
-}
+###---    pushd ${SST_ROOT}/sst-elements/src/sst/elements/ember/test
+    pushd ${SST_TEST_SUITES}/emberSweep_folder
+}   
 ####################
 #    SE_fini()
 #          tmp_file is output from SST
@@ -158,19 +163,20 @@ SE_fini() {
    if [ $FAILED == "TRUE" ] ; then
        FAILED_TESTS=$(($FAILED_TESTS + 1))
        echo ' '
-       grep Ember_${1} -A 5 ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/${SSTTESTTEMPFILES}/bashIN | grep sst
+       grep Ember_${1} -A 5 ${SSTTESTTEMPFILES}/bashIN | grep sst
        echo ' '
-       wc ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/tmp_file
-       len_tmp_file=`wc -l ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/tmp_file | awk '{print $1}'`
+###---       wc ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/tmp_file
+       wc tmp_file
+       len_tmp_file=`wc -l ./tmp_file | awk '{print $1}'`
        if [ $len_tmp_file -gt 25 ] ; then
            echo "      stdout from sst   first and last 25 lines"
-           Sed 25q ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/tmp_file
+           Sed 25q ./tmp_file
            echo "              . . ."      
-           tail -25 ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/tmp_file
+           tail -25 ./tmp_file
            echo "    ----   end of stdout "
        else
            echo "    ----   stdout for sst:"
-           cat ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/tmp_file
+           cat ./tmp_file
            echo "    ----   end of stdout "
        fi
        echo ' '
@@ -268,5 +274,5 @@ popd
 export SST_TEST_ONE_TEST_TIMEOUT=900
 cd $SST_ROOT
 
-(. ${SHUNIT2_SRC}/shunit2 ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/${SSTTESTTEMPFILES}/bashIN)
+(. ${SHUNIT2_SRC}/shunit2 ${SSTTESTTEMPFILES}/bashIN)
 

--- a/test/testSuites/testSuite_EmberSweep.sh
+++ b/test/testSuites/testSuite_EmberSweep.sh
@@ -158,7 +158,7 @@ SE_fini() {
    if [ $FAILED == "TRUE" ] ; then
        FAILED_TESTS=$(($FAILED_TESTS + 1))
        echo ' '
-       grep Ember_${1} -A 5 ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/bashIN | grep sst
+       grep Ember_${1} -A 5 ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/${SSTTESTTEMPFILES}/bashIN | grep sst
        echo ' '
        wc ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/tmp_file
        len_tmp_file=`wc -l ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/tmp_file | awk '{print $1}'`
@@ -198,7 +198,7 @@ SE_fini() {
         sed -i.x '/print..sst.*model/s/..sst/ "mpirun -np '"${SST_MULTI_RANK_COUNT}"' sst/' EmberSweepGenerator.py 
     fi
 
-    ./EmberSweepGenerator.py > bashIN
+    ./EmberSweepGenerator.py > ${SSTTESTTEMPFILES}/bashIN
     if [ $? -ne 0 ] ; then 
         preFail " Test Generation FAILED"
     fi
@@ -210,7 +210,7 @@ SE_fini() {
      SE_SELECT=0
      if [[ ${SST_TEST_SE_LIST:+isSet} == isSet ]] ; then
          SE_SELECT=1
-         mv bashIN bashIN0
+         mv ${SSTTESTTEMPFILES}/bashIN ${SSTTESTTEMPFILES}/bashIN0
          ICT=1
          for IND in $SST_TEST_SE_LIST
          do
@@ -242,19 +242,19 @@ SE_fini() {
                    INDR=$(($INDR+1))
                 done    
                fi
-               sed -n ${START},${END}p  bashIN0 >> bashIN
+               sed -n ${START},${END}p  ${SSTTESTTEMPFILES}/bashIN0 >> ${SSTTESTTEMPFILES}/bashIN
           done
 
 # Check it
 echo Check the result
-wc bashIN
+wc ${SSTTESTTEMPFILES}/bashIN
 ## for i in ${SE_LIST[@]}; do echo $i; done
 
      fi
 
 #    Source the bash file
 
-    . bashIN
+    . ${SSTTESTTEMPFILES}/bashIN
 
 
 export SHUNIT_OUTPUTDIR=$SST_TEST_RESULTS
@@ -268,5 +268,5 @@ popd
 export SST_TEST_ONE_TEST_TIMEOUT=900
 cd $SST_ROOT
 
-(. ${SHUNIT2_SRC}/shunit2 ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/bashIN)
+(. ${SHUNIT2_SRC}/shunit2 ${SST_ROOT}/sst-elements/src/sst/elements/ember/test/${SSTTESTTEMPFILES}/bashIN)
 

--- a/test/testSuites/testSuite_SiriusZodiacTrace.sh
+++ b/test/testSuites/testSuite_SiriusZodiacTrace.sh
@@ -43,7 +43,6 @@ L_TESTFILE=()  # Empty list, used to hold test file names
 
 #       Download the tar file of traces   and untar it into the sst-elements/src/sst/elements tree
 #
-###---     pushd ${SST_ROOT}/sst-elements/src
      mkdir ${SST_TEST_SUITES}/SiriusZ_folder
      cd ${SST_TEST_SUITES}/SiriusZ_folder
      echo "wget https://github.com/sstsimulator/sst-downloads/releases/download/TestFiles/sst-Sirius-Allreduce-traces.tar.gz --no-check-certificate"
@@ -54,19 +53,13 @@ L_TESTFILE=()  # Empty list, used to hold test file names
      fi
      tar -xzf sst-Sirius-Allreduce-traces.tar.gz
      
-echo "$LINENO --- PWD  `pwd`"
-ls
      rm sst-Sirius-Allreduce-traces.tar.gz
-###---   popd 
 
 ##   Right now this feels to me like the "allreduce template", rather than "Sirius".
 allReduce_template() {
 Sirius_case=$1
 Tol=$2    ##  curTick tolerance,  or  "lineWordCt" 
 
-     
-echo "$LINENO --- PWD  `pwd`"
-ls
     startSeconds=`date +%s`
     testDataFileBase="test_Sirius_allred_$Sirius_case"
     outFile="${SST_TEST_OUTPUTS}/${testDataFileBase}.out"
@@ -77,7 +70,6 @@ ls
     # Add basename to list for XML processing later
     L_TESTFILE+=(${testDataFileBase})
 
-###---    pushd $SST_ROOT/sst-elements/src/sst/elements/zodiac/test/allreduce
     pushd ./sst/elements/zodiac/test/allreduce
     pwd
 

--- a/test/testSuites/testSuite_SiriusZodiacTrace.sh
+++ b/test/testSuites/testSuite_SiriusZodiacTrace.sh
@@ -43,7 +43,9 @@ L_TESTFILE=()  # Empty list, used to hold test file names
 
 #       Download the tar file of traces   and untar it into the sst-elements/src/sst/elements tree
 #
-     pushd ${SST_ROOT}/sst-elements/src
+###---     pushd ${SST_ROOT}/sst-elements/src
+     mkdir ${SST_TEST_SUITES}/SiriusZ_folder
+     cd ${SST_TEST_SUITES}/SiriusZ_folder
      echo "wget https://github.com/sstsimulator/sst-downloads/releases/download/TestFiles/sst-Sirius-Allreduce-traces.tar.gz --no-check-certificate"
      wget "https://github.com/sstsimulator/sst-downloads/releases/download/TestFiles/sst-Sirius-Allreduce-traces.tar.gz"
      if [ $? != 0 ] ; then
@@ -52,14 +54,19 @@ L_TESTFILE=()  # Empty list, used to hold test file names
      fi
      tar -xzf sst-Sirius-Allreduce-traces.tar.gz
      
+echo "$LINENO --- PWD  `pwd`"
+ls
      rm sst-Sirius-Allreduce-traces.tar.gz
-     popd 
+###---   popd 
 
 ##   Right now this feels to me like the "allreduce template", rather than "Sirius".
 allReduce_template() {
 Sirius_case=$1
 Tol=$2    ##  curTick tolerance,  or  "lineWordCt" 
 
+     
+echo "$LINENO --- PWD  `pwd`"
+ls
     startSeconds=`date +%s`
     testDataFileBase="test_Sirius_allred_$Sirius_case"
     outFile="${SST_TEST_OUTPUTS}/${testDataFileBase}.out"
@@ -70,7 +77,9 @@ Tol=$2    ##  curTick tolerance,  or  "lineWordCt"
     # Add basename to list for XML processing later
     L_TESTFILE+=(${testDataFileBase})
 
-    pushd $SST_ROOT/sst-elements/src/sst/elements/zodiac/test/allreduce
+###---    pushd $SST_ROOT/sst-elements/src/sst/elements/zodiac/test/allreduce
+    pushd ./sst/elements/zodiac/test/allreduce
+    pwd
 
     sut="${SST_TEST_INSTALL_BIN}/sst"
 

--- a/test/testSuites/testSuite_cacheTracer.sh
+++ b/test/testSuites/testSuite_cacheTracer.sh
@@ -137,7 +137,6 @@ test_cacheTracer_2() {
     sut="${SST_TEST_INSTALL_BIN}/sst"
     mkdir $SST_TEST_SUITES/cacheTracer_folder
     pushd $SST_TEST_SUITES/cacheTracer_folder
-###---    cd ${SST_ROOT}/sst-elements/src/sst/elements/cacheTracer/tests
 
     sutArgs="${SST_ROOT}/sst-elements/src/sst/elements/cacheTracer/tests/test_cacheTracer_2.py"
 

--- a/test/testSuites/testSuite_cacheTracer.sh
+++ b/test/testSuites/testSuite_cacheTracer.sh
@@ -101,14 +101,14 @@ test_cacheTracer_1() {
              return
         fi
         wc $referenceFile $outFile
-        diff -b $referenceFile $outFile > _raw_diff
+        diff -b $referenceFile $outFile > ${SSTTESTTEMPFILES}/_raw_diff
         if [ $? != 0 ]
         then  
-           wc _raw_diff
+           wc ${SSTTESTTEMPFILES}/_raw_diff
            compare_sorted $referenceFile $outFile
            if [ $? == 0 ] ; then
               echo " Sorted match with Reference File"
-              rm _raw_diff
+              rm ${SSTTESTTEMPFILES}/_raw_diff
               return
            else
               fail " Reference does not Match Output"

--- a/test/testSuites/testSuite_cacheTracer.sh
+++ b/test/testSuites/testSuite_cacheTracer.sh
@@ -135,7 +135,9 @@ test_cacheTracer_2() {
 
     # Define Software Under Test (SUT) and its runtime arguments
     sut="${SST_TEST_INSTALL_BIN}/sst"
-    cd ${SST_ROOT}/sst-elements/src/sst/elements/cacheTracer/tests
+    mkdir $SST_TEST_SUITES/cacheTracer_folder
+    pushd $SST_TEST_SUITES/cacheTracer_folder
+###---    cd ${SST_ROOT}/sst-elements/src/sst/elements/cacheTracer/tests
 
     sutArgs="${SST_ROOT}/sst-elements/src/sst/elements/cacheTracer/tests/test_cacheTracer_2.py"
 
@@ -144,6 +146,7 @@ ls $outFile
     if [ -f ${sut} ] && [ -x ${sut} ]
     then
         # Run SUT
+pwd
         (${sut} ${sutArgs} > $outFile)
         RetVal=$? 
         TIME_FLAG=/tmp/TimeFlag_$$_${__timerChild} 

--- a/test/testSuites/testSuite_cassini_prefetch.sh
+++ b/test/testSuites/testSuite_cassini_prefetch.sh
@@ -97,17 +97,17 @@ CP_case=$1
      RemoveComponentWarning
      grep "simulated.time" $outFile ; echo ' '
      wc  $outFile $referenceFile
-     diff -b $referenceFile $outFile > _raw_diff
+     diff -b $referenceFile $outFile > ${SSTTESTTEMPFILES}/_raw_diff
      if [ $? != 0 ] ; then
-        wc _raw_diff
+        wc ${SSTTESTTEMPFILES}/_raw_diff
         compare_sorted $referenceFile $outFile
         if [ $? == 0 ] ; then
            echo " Sorted match with Reference File"
-           rm _raw_diff
+           rm ${SSTTESTTEMPFILES}/_raw_diff
            return
         else
            echo "Output does not match Reference File"
-           cat _raw_diff
+           cat ${SSTTESTTEMPFILES}/_raw_diff
 #           echo " Reference File "
 #           cat $referenceFile
 #           echo "       ------  "
@@ -115,7 +115,7 @@ CP_case=$1
 #           cat $outFile
 #           echo "       ------  "
            fail "Output does not match Reference File"
-           rm _raw_diff
+           rm ${SSTTESTTEMPFILES}/_raw_diff
         fi
      else
         echo ' '

--- a/test/testSuites/testSuite_embernightly.sh
+++ b/test/testSuites/testSuite_embernightly.sh
@@ -113,7 +113,7 @@ test_embernightly() {
              return
         fi
         wc $referenceFile $outFile
-        diff ${referenceFile} ${outFile} > full.diff 
+        diff ${referenceFile} ${outFile} > ${SSTTESTTEMPFILES}/full.diff 
         if [ $? -ne 0 ]
         then
             ref=`wc ${referenceFile} | awk '{print $1, $2}'`; 
@@ -125,7 +125,7 @@ test_embernightly() {
                 echo "    Output Flunked  lineWordCt Count match"
                 fail "    Output Flunked  lineWordCt Count match"
             fi
-            wc full.diff
+            wc ${SSTTESTTEMPFILES}/full.diff
             lcr=`wc -l $referenceFile | awk '{print $1}'`
             lco=`wc -l $outFile | awk '{print $1}'`
             if [ $lco -gt $lcr ] ; then
@@ -134,7 +134,7 @@ test_embernightly() {
                 echo "     $(($lcr-$lco)) lines less in output"
             fi
             echo "            *** Tail of Diff ***"
-            tail -10 full.diff
+            tail -10 ${SSTTESTTEMPFILES}/full.diff
         else
             grep 'Simulation is complete' $outFile
             echo "    Output matches Reference File exactly"

--- a/test/testSuites/testSuite_memHA.sh
+++ b/test/testSuites/testSuite_memHA.sh
@@ -113,18 +113,18 @@ Match=$2    ##  Match criteron
 
         pushd ${SSTTESTTEMPFILES}
 
-        diff -b $referenceFile $outFile > _raw_diff
+        diff -b $referenceFile $outFile > ${SSTTESTTEMPFILES}/_raw_diff
         if [ $? == 0 ] ; then
              echo "PASS:  Exact match $memHA_case"
-             rm _raw_diff
+             rm ${SSTTESTTEMPFILES}/_raw_diff
         else
              wc $referenceFile $outFile
-             wc _raw_diff
+             wc ${SSTTESTTEMPFILES}/_raw_diff
              rm diff_sorted
              compare_sorted $referenceFile $outFile
              if [ $? == 0 ] ; then
                  echo "PASS:  Sorted match $memHA_case"
-                 rm _raw_diff
+                 rm ${SSTTESTTEMPFILES}/_raw_diff
              elif [ "lineWordCt" == "$Match" ] || [[ ${SST_MULTI_CORE:+isSet} != isSet ]] ; then
                  ref=`wc ${referenceFile} | awk '{print $1, $2}'`; 
                  new=`wc ${outFile}       | awk '{print $1, $2}'`;

--- a/test/testSuites/testSuite_memHSieve.sh
+++ b/test/testSuites/testSuite_memHSieve.sh
@@ -70,7 +70,7 @@ fi
         
 pushd $SST_ROOT/sst-elements/src/sst/elements/memHierarchy/Sieve/tests
 #   Remove old files if any
-rm -f ompsievetest.o ompsievetest backtrace_* StatisticOutput.csv mallocRank.txt-0.txt 23_43.ref 23_43.out
+rm -f ompsievetest.o ompsievetest backtrace_* StatisticOutput.csv mallocRank.txt-0.txt ${SSTTESTTEMPFILES}/23_43.ref ${SSTTESTTEMPFILES}/23_43.out
 
 #   Build ompsievetest
     #      Optionally remove openmp from the build
@@ -179,11 +179,11 @@ ls -ltr
    echo  "         4 - Look at StatisticOutput.csv"
         wc $referenceFile $outFile
 
-        grep -w -e '^.$' -e '^..$' $referenceFile  > 23_43.ref
-        grep -w -e '^.$' -e '^..$' $outFile > 23_43.out 
-        wc 23_43.???
+        grep -w -e '^.$' -e '^..$' $referenceFile  > ${SSTTESTTEMPFILES}/23_43.ref
+        grep -w -e '^.$' -e '^..$' $outFile > ${SSTTESTTEMPFILES}/23_43.out 
+        wc ${SSTTESTTEMPFILES}/23_43.???
 
-        diff 23_43.ref 23_43.out
+        diff ${SSTTESTTEMPFILES}/23_43.ref ${SSTTESTTEMPFILES}/23_43.out
         if [ $? != 0 ] ; then
            echo " lines 23 to 43 of csv gold did not match"
            FAIL=1

--- a/test/testSuites/testSuite_memHSieve.sh
+++ b/test/testSuites/testSuite_memHSieve.sh
@@ -67,12 +67,14 @@ fi
         fi
     fi
 
-        
-pushd $SST_ROOT/sst-elements/src/sst/elements/memHierarchy/Sieve/tests
+mkdir $SST_TEST_SUITES/memHS_folder        
+pushd $SST_TEST_SUITES/memHS_folder        
 #   Remove old files if any
 rm -f ompsievetest.o ompsievetest backtrace_* StatisticOutput.csv mallocRank.txt-0.txt ${SSTTESTTEMPFILES}/23_43.ref ${SSTTESTTEMPFILES}/23_43.out
 
 #   Build ompsievetest
+    cp $SST_ROOT/sst-elements/src/sst/elements/memHierarchy/Sieve/tests/Makefile .
+    ln -s $SST_ROOT/sst-elements/src/sst/elements/memHierarchy/Sieve/tests/ompsievetest.c
     #      Optionally remove openmp from the build
     if [ $SST_WITH_OPENMP == 0 ] ; then
         echo "         ### Remove \"-fopenmp\" from the make"
@@ -80,8 +82,6 @@ rm -f ompsievetest.o ompsievetest backtrace_* StatisticOutput.csv mallocRank.txt
     fi
     make
     ls -l ompsievetest
-
-popd
 
 test_memHSieve() {
 
@@ -98,7 +98,6 @@ test_memHSieve() {
     # Define Software Under Test (SUT) and its runtime arguments
     sut="${SST_TEST_INSTALL_BIN}/sst"
     sutArgs="${SST_ROOT}/sst-elements/src/sst/elements/memHierarchy/Sieve/tests/sieve-test.py"
-    pushd ${SST_ROOT}/sst-elements/src/sst/elements/memHierarchy/Sieve/tests
     rm -f StatisticOutput*csv
     rm -f mallocRank.txt-0*
 

--- a/test/testSuites/testSuite_memHierarchy_sdl.sh
+++ b/test/testSuites/testSuite_memHierarchy_sdl.sh
@@ -140,19 +140,19 @@ Tol=$2    ##  curTick tolerance
     RemoveComponentWarning
     pushd ${SSTTESTTEMPFILES}
 #          Append errFile to outFile   w/o  Not Aligned messages
-    diff -b $referenceFile $outFile > _raw_diff
+    diff -b $referenceFile $outFile > ${SSTTESTTEMPFILES}/_raw_diff
     if [ $? == 0 ] ; then
         fileSize=`wc -l $outFile | awk '{print $1}'`
         echo "            Exact Match of reduced Output  -- $fileSize lines"
-        rm _raw_diff
+        rm ${SSTTESTTEMPFILES}/_raw_diff
     else
         wc $referenceFile $outFile
-        wc _raw_diff
+        wc ${SSTTESTTEMPFILES}/_raw_diff
         rm diff_sorted
         compare_sorted $referenceFile $outFile
         if [ $? == 0 ] ; then
            echo " Sorted match with Reference File"
-           rm _raw_diff
+           rm ${SSTTESTTEMPFILES}/_raw_diff
         else
 echo "Preliminary ---------------"
 cat ${SSTTESTTEMPFILES}/diff_sorted

--- a/test/testSuites/testSuite_partitioner.sh
+++ b/test/testSuites/testSuite_partitioner.sh
@@ -308,10 +308,10 @@ echo "DEBUG: numrank $numranks, was $was"
         wc $distResultFile
 
             #         Source $distResultFile (with the RANK array)
-            . $distResultFile 2>std.err
-            if [ -s std.err ] ; then
+            . $distResultFile 2>${SSTTESTTEMPFILES}/std.err
+            if [ -s ${SSTTESTTEMPFILES}/std.err ] ; then
                  echo "source of $distResultFile failed:"
-                 cat std.err
+                 cat ${SSTTESTTEMPFILES}/std.err
                  fail " Source of $distResultFile failed"
                  return
             fi

--- a/test/testSuites/testSuite_partitioner.sh
+++ b/test/testSuites/testSuite_partitioner.sh
@@ -244,27 +244,27 @@ PARTITIONER=$2
             numComp=`grep found $outFile | grep in.partition.graph | awk -F'found' '{print $2}' | awk '{print $1 }'`
             
             #   Collect number rank 0 sends to each other rank
-            grep Export.to.rank $outFile | awk '{print "rank[" $8 "]=" $10 ";"}'> af
-            numranks=`wc -l af | awk '{print $1}'` ; ((numranks++))
+            grep Export.to.rank $outFile | awk '{print "rank[" $8 "]=" $10 ";"}'> ${SSTTESTTEMPFILES}/af
+            numranks=`wc -l ${SSTTESTTEMPFILES}/af | awk '{print $1}'` ; ((numranks++))
             echo " Total vertices: $numComp, numranks = $numranks "
 
             # Insert a sanity Check.   This has failed twice on Mavericks!
-            OtherRanks=`wc -l af | awk '{print $1}'`
+            OtherRanks=`wc -l ${SSTTESTTEMPFILES}/af | awk '{print $1}'`
             ((OtherRanks++))   # Include rank zero
             #               BAD USAGE   numranks and NUMRANKS
             #           Verify that output file is valid
             if [ $OtherRanks != $NUMRANKS ] ; then
                 echo "test assumptions not met"
     #            fail "test assumptions not met"
-                cat af
+                cat ${SSTTESTTEMPFILES}/af
                 wc $outFile
                 grep -e Export -e 'to.rank' -B 4 -A 4 $outFile
                 return
             fi
 
-            . af     #  Source the file (create array of components on node)
+            . ${SSTTESTTEMPFILES}/af     #  Source the file (create array of components on node)
 #
-#   LOGIC PROBLEM extracting as subroutine this requires prior source of af!
+#   LOGIC PROBLEM extracting as subroutine this requires prior source of ${SSTTESTTEMPFILES}/af!
 #            
             #     Find out how many left on rank 0
             rank[0]=$numComp

--- a/test/testSuites/testSuite_prospero.sh
+++ b/test/testSuites/testSuite_prospero.sh
@@ -41,8 +41,14 @@ if [[ ${SST_BUILD_PROSPERO_TRACE_FILE:+isSet} == isSet ]] ; then
 
    # ----------------- compile the file array     
    echo "## ----------------- compile the file array   "
-       cd ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array
+###---       cd ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array
+   mkdir ${SST_TEST_SUITES}/Prospero_folder
+   cd ${SST_TEST_SUITES}/Prospero_folder
    echo PWD `pwd`
+       ln -s ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array/Makefile .
+       ln -s ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array/array.c .
+       ln -s ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array/*.py .
+
        make clean
        make
    ls -l 
@@ -63,7 +69,7 @@ if [[ ${SST_BUILD_PROSPERO_TRACE_FILE:+isSet} == isSet ]] ; then
        PIN_TAR="Pin"
 else
    #  Download the trace files from sst-simulator.org
-       cd ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array
+###=--       cd ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array
        echo "wget https://github.com/sstsimulator/sst-downloads/releases/download/TestFiles/Prospero-trace-files.tar.gz --no-check-certificate"
        wget "https://github.com/sstsimulator/sst-downloads/releases/download/TestFiles/Prospero-trace-files.tar.gz" 
        if [ $? != 0 ] ; then

--- a/test/testSuites/testSuite_prospero.sh
+++ b/test/testSuites/testSuite_prospero.sh
@@ -33,6 +33,9 @@ L_BUILDTYPE=$1 # Build type, passed in from bamboo.sh as a convenience
 
 L_TESTFILE=()  # Empty list, used to hold test file names
  
+rm -rf ${SST_TEST_SUITES}/Prospero_folder
+mkdir ${SST_TEST_SUITES}/Prospero_folder
+cd ${SST_TEST_SUITES}/Prospero_folder
 if [[ ${SST_BUILD_PROSPERO_TRACE_FILE:+isSet} == isSet ]] ; then
     if [[ $SST_TEST_HOST_OS_DISTRIB_VERSION == *10.10* ]] ; then
       preFail "SKIP: Prospero Pin does not work on Yosemite - July 2016"  "skip"
@@ -41,10 +44,6 @@ if [[ ${SST_BUILD_PROSPERO_TRACE_FILE:+isSet} == isSet ]] ; then
 
    # ----------------- compile the file array     
    echo "## ----------------- compile the file array   "
-###---       cd ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array
-   mkdir ${SST_TEST_SUITES}/Prospero_folder
-   cd ${SST_TEST_SUITES}/Prospero_folder
-   echo PWD `pwd`
        ln -s ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array/Makefile .
        ln -s ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array/array.c .
        ln -s ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array/*.py .
@@ -69,7 +68,6 @@ if [[ ${SST_BUILD_PROSPERO_TRACE_FILE:+isSet} == isSet ]] ; then
        PIN_TAR="Pin"
 else
    #  Download the trace files from sst-simulator.org
-###=--       cd ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array
        echo "wget https://github.com/sstsimulator/sst-downloads/releases/download/TestFiles/Prospero-trace-files.tar.gz --no-check-certificate"
        wget "https://github.com/sstsimulator/sst-downloads/releases/download/TestFiles/Prospero-trace-files.tar.gz" 
        if [ $? != 0 ] ; then
@@ -109,7 +107,8 @@ wcomma() {
 #              trace file type:  (text, binary, compressed)
 #              with or without DramSim  ("DramSim" or other, "none", blank)
 template_prospero() {
-    ls ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array/*.trace > /dev/null 2>&1
+    cd ${SST_TEST_SUITES}/Prospero_folder
+    ls ${SST_TEST_SUITES}/Prospero_folder/*.trace > /dev/null 2>&1
     rt=$?
     if [ 0 != $rt ] ; then
         fail "No trace file found (rt = $rt)"
@@ -121,11 +120,9 @@ template_prospero() {
     # files. XML postprocessing requires this.
     if [ "$2" != "DramSim" ] ; then
          testDataFileBase="test_prospero_wo_dramsim"
-         # echo ' ' ; echo "        entering test  $TYPE  without DramSim" ; pwd ; echo ' '
          useDRAMSIM="no"
     else
          testDataFileBase="test_prospero_with_dramsim"
-         # echo ' ' ; echo "        entering test  $TYPE  with DramSim" ; pwd ; echo ' '
          useDRAMSIM="yes"
          echo ' '
     fi
@@ -137,8 +134,6 @@ template_prospero() {
     # Define Software Under Test (SUT) and its runtime arguments
     sut="${SST_TEST_INSTALL_BIN}/sst"
     sutArgs="${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array/trace-common.py"
-    cd ${SST_ROOT}/sst-elements/src/sst/elements/prospero/tests/array
-
 
     if [ -f ${sut} ] && [ -x ${sut} ]
     then
@@ -195,6 +190,7 @@ template_prospero() {
         else
             echo "OutFile word/line count DOES NOT matches Reference"
             fail "OutFile word/line count DOES NOT matches Reference"
+            diff $outFile $referenceFile
         fi
     else
         echo OutFile is an exact match of ReferenceFile

--- a/test/testSuites/testSuite_simpleComponent.sh
+++ b/test/testSuites/testSuite_simpleComponent.sh
@@ -87,14 +87,14 @@ test_simpleComponent() {
              return
         fi
         wc $referenceFile $outFile
-        diff -b $referenceFile $outFile > _raw_diff
+        diff -b $referenceFile $outFile > ${SSTTESTTEMPFILES}/_raw_diff
         if [ $? != 0 ]
         then  
-           wc _raw_diff
+           wc ${SSTTESTTEMPFILES}/_raw_diff
            compare_sorted $referenceFile $outFile
            if [ $? == 0 ] ; then
               echo " Sorted match with Reference File"
-              rm _raw_diff
+              rm ${SSTTESTTEMPFILES}/_raw_diff
               return
            else
               fail " Reference does not Match Output"

--- a/test/testSuites/testSuite_simpleLookupTableComponent.sh
+++ b/test/testSuites/testSuite_simpleLookupTableComponent.sh
@@ -114,7 +114,6 @@ test_simpleLookupTableComponent() {
               return
            else
               fail " Reference does not Match Output"
-              # cat ${SSTTESTTEMPFILES}/_raw_diff
               echo "Display up to 20 lines of Sorted Diff"
               cat diff_sorted| sed 20q  ; echo ' '
            fi

--- a/test/testSuites/testSuite_simpleLookupTableComponent.sh
+++ b/test/testSuites/testSuite_simpleLookupTableComponent.sh
@@ -103,18 +103,18 @@ test_simpleLookupTableComponent() {
         fi
         RemoveComponentWarning
         wc $referenceFile $outFile
-        diff -b $referenceFile $outFile > _raw_diff
+        diff -b $referenceFile $outFile > ${SSTTESTTEMPFILES}/_raw_diff
         if [ $? != 0 ]
         then  
-           wc _raw_diff
+           wc ${SSTTESTTEMPFILES}/_raw_diff
            compare_sorted $referenceFile $outFile
            if [ $? == 0 ] ; then
               echo " Sorted match with Reference File"
-              rm _raw_diff
+              rm ${SSTTESTTEMPFILES}/_raw_diff
               return
            else
               fail " Reference does not Match Output"
-              # cat _raw_diff
+              # cat ${SSTTESTTEMPFILES}/_raw_diff
               echo "Display up to 20 lines of Sorted Diff"
               cat diff_sorted| sed 20q  ; echo ' '
            fi

--- a/test/testSuites/testSuite_simpleMessageGeneratorComponent.sh
+++ b/test/testSuites/testSuite_simpleMessageGeneratorComponent.sh
@@ -99,14 +99,14 @@ test_simpleMessageGeneratorComponent() {
         fi
         RemoveComponentWarning
         wc $referenceFile $outFile
-        diff -b $referenceFile $outFile > _raw_diff
+        diff -b $referenceFile $outFile > ${SSTTESTTEMPFILES}/_raw_diff
         if [ $? != 0 ]
         then
-           wc _raw_diff
+           wc ${SSTTESTTEMPFILES}/_raw_diff
            compare_sorted $referenceFile $outFile
            if [ $? == 0 ] ; then
               echo " Sorted match with Reference File"
-              rm _raw_diff
+              rm ${SSTTESTTEMPFILES}/_raw_diff
               return
            else
               fail " Reference does not Match Output"

--- a/test/testSuites/testSuite_zoltan.sh
+++ b/test/testSuites/testSuite_zoltan.sh
@@ -153,7 +153,6 @@ checkAndPrint() {
             alln=`grep found $outFile | grep in.partition.graph | awk -F'found' '{print $2}' | awk '{print $1 }'`
             
             grep 'rank .* (assigned .* components)' $outFile | awk -F'rank' '{print $2}' | awk '{print "rank[" $1 "]=" $3}' > ${af}
-#            grep Export.to.rank $outFile | awk '{print "rank[" $8 "]=" $10 ";"}'> ${af}
             numranks=`wc -l ${af} | awk '{print $1}'` ; ((numranks++))
             echo " Total vertices: $alln, numranks = $numranks "
 

--- a/test/testSuites/testSuite_zoltan.sh
+++ b/test/testSuites/testSuite_zoltan.sh
@@ -149,26 +149,27 @@ checkAndPrint() {
             echo ' '
             grep Export.to.rank $outFile
             
+            af=${SSTTESTTEMPFILES}/af
             alln=`grep found $outFile | grep in.partition.graph | awk -F'found' '{print $2}' | awk '{print $1 }'`
             
-            grep 'rank .* (assigned .* components)' $outFile | awk -F'rank' '{print $2}' | awk '{print "rank[" $1 "]=" $3}' > af
-#            grep Export.to.rank $outFile | awk '{print "rank[" $8 "]=" $10 ";"}'> af
-            numranks=`wc -l af | awk '{print $1}'` ; ((numranks++))
+            grep 'rank .* (assigned .* components)' $outFile | awk -F'rank' '{print $2}' | awk '{print "rank[" $1 "]=" $3}' > ${af}
+#            grep Export.to.rank $outFile | awk '{print "rank[" $8 "]=" $10 ";"}'> ${af}
+            numranks=`wc -l ${af} | awk '{print $1}'` ; ((numranks++))
             echo " Total vertices: $alln, numranks = $numranks "
 
             # Insert a sanity Check.   This has failed twice on Mavericks!
-            OtherRanks=`wc -l af | awk '{print $1}'`
+            OtherRanks=`wc -l ${af} | awk '{print $1}'`
             ((OtherRanks++))   # Include rank zero
             #               BAD USAGE   numranks and NUMRANKS
             if [ $OtherRanks != $NUMRANKS ] ; then
                 fail "test assumptions not met"
-                cat af
+                cat ${af}
                 wc $outFile
                 grep -e Export -e 'to.rank' -B 4 -A 4 $outFile
                 return
             fi
 
-            . af
+            . ${af}
             
             rank[0]=$alln
             ind=1

--- a/test/utilities/timeLimitEnforcer.sh
+++ b/test/utilities/timeLimitEnforcer.sh
@@ -39,15 +39,15 @@ echo ' '
 ####                 Remove old ompsievetest task
 ps -ef | grep ompsievetest
 echo " this might better go in the Suite"
-ps -ef | grep ompsievetest | grep -v -e grep > omps_list
-wc omps_list
+ps -ef | grep ompsievetest | grep -v -e grep > ${SSTTESTTEMPFILES}/omps_list
+wc ${SSTTESTTEMPFILES}/omps_list
 while read -u 3 _who _anOMP _own _rest
 do
     if [ $_own == 1 ] ; then
         echo " Attempt to remove $_anOMP "
         kill -9 $_anOMP
     fi
-done 3<omps_list
+done 3<${SSTTESTTEMPFILES}/omps_list
 
 ####                  Find Pid of my ompsievetest
 OMP_PID=`ps -ef | awk '{print $1,$2,$3,$4,$5,$6,$7,$8}' | grep ompsievetest | grep -v -e grep | awk '{print $2}'`

--- a/test/utilities/timeLimitEnforcer.sh
+++ b/test/utilities/timeLimitEnforcer.sh
@@ -39,16 +39,17 @@ echo ' '
 ####                 Remove old ompsievetest task
 ps -ef | grep ompsievetest
 echo " this might better go in the Suite"
-ps -ef | grep ompsievetest | grep -v -e grep > ${SSTTESTTEMPFILES}/omps_list
-wc ${SSTTESTTEMPFILES}/omps_list
+ps -ef | grep ompsievetest | grep -v -e grep > /tmp/${MY_PID}_omps_list
+wc /tmp/${MY_PID}_omps_list
 while read -u 3 _who _anOMP _own _rest
 do
     if [ $_own == 1 ] ; then
         echo " Attempt to remove $_anOMP "
         kill -9 $_anOMP
     fi
-done 3<${SSTTESTTEMPFILES}/omps_list
+done 3</tmp/${MY_PID}_omps_list
 
+rm /tmp/${MY_PID}_omps_list
 ####                  Find Pid of my ompsievetest
 OMP_PID=`ps -ef | awk '{print $1,$2,$3,$4,$5,$6,$7,$8}' | grep ompsievetest | grep -v -e grep | awk '{print $2}'`
 echo "OMP_PID = $OMP_PID"


### PR DESCRIPTION
The main change distributed among many test Suites is to move all writes to elements for the testing to the (SQE) test sub-tree.

Testing on the Any Branch tester inspired resolving the conflict between out-of-source build and the make-dist test.

Finally an option (environment variable) was introduced in bamboo.sh (dotests) to verify that the move is complete, to remove write permission from the elements sub-tree before running the tests.