### PR TITLE
Refine definition of map-by

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -247,11 +247,14 @@ echo " #####################################################"
 
     if [[ ${SST_MULTI_THREAD_COUNT:+isSet} == isSet ]] ||
        [[ ${SST_MULTI_RANK_COUNT:+isSet} == isSet ]] ; then
-           set_map-by_parameter
     #    This subroutine is in test/include/testDefinitions.sh
     #    (It is a subroutine, but testSubroutines is only sourced
     #        into test Suites, not bamboo.sh.
          multithread_multirank_patch_Suites
+    fi
+    #    The following is to include the map-by numa parameter
+    if [[ ${SST_MULTI_RANK_COUNT:+isSet} == isSet ]] && [ ${SST_MULTI_RANK_COUNT} -gt 1 ] ; then
+           set_map-by_parameter
     fi
     #       Recover library path
     export LD_LIBRARY_PATH=$SAVE_LIBRARY_PATH

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -253,6 +253,7 @@ echo " #####################################################"
          multithread_multirank_patch_Suites
     fi
     #    The following is to include the map-by numa parameter
+    export NUMA_PARAM=" "
     if [[ ${SST_MULTI_RANK_COUNT:+isSet} == isSet ]] && [ ${SST_MULTI_RANK_COUNT} -gt 1 ] ; then
            set_map-by_parameter
     fi


### PR DESCRIPTION
Initialize the environment variable NUMA_PARAM to a blank.
Only define a value if rank count is defined and greater than 1.