### PR TITLE
Get the rest

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -247,11 +247,15 @@ echo " #####################################################"
 
     if [[ ${SST_MULTI_THREAD_COUNT:+isSet} == isSet ]] ||
        [[ ${SST_MULTI_RANK_COUNT:+isSet} == isSet ]] ; then
-           set_map-by_parameter
     #    This subroutine is in test/include/testDefinitions.sh
     #    (It is a subroutine, but testSubroutines is only sourced
     #        into test Suites, not bamboo.sh.
          multithread_multirank_patch_Suites
+    fi
+    #    The following is to include the map-by numa parameter
+    export NUMA_PARAM=" "
+    if [[ ${SST_MULTI_RANK_COUNT:+isSet} == isSet ]] && [ ${SST_MULTI_RANK_COUNT} -gt 1 ] ; then
+           set_map-by_parameter
     fi
     #       Recover library path
     export LD_LIBRARY_PATH=$SAVE_LIBRARY_PATH

--- a/test/testSuites/testSuite_Messier.sh
+++ b/test/testSuites/testSuite_Messier.sh
@@ -66,7 +66,7 @@ Tol=$2    ##  curTick tolerance
            ${sut} ${sutArgs} > ${outFile}
            RetVal=$? 
         else
-           mpirun -np ${SST_MULTI_RANK_COUNT} -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
+           mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
            RetVal=$? 
            cat ${testOutFiles}* > $outFile
         fi

--- a/test/testSuites/testSuite_Samba.sh
+++ b/test/testSuites/testSuite_Samba.sh
@@ -66,7 +66,7 @@ Tol=$2    ##  curTick tolerance
            ${sut} ${sutArgs} > ${outFile}
            RetVal=$? 
         else
-           mpirun -np ${SST_MULTI_RANK_COUNT} -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
+           mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
            RetVal=$? 
            cat ${testOutFiles}* > $outFile
         fi

--- a/test/testSuites/testSuite_SiriusZodiacTrace.sh
+++ b/test/testSuites/testSuite_SiriusZodiacTrace.sh
@@ -87,7 +87,7 @@ echo "------------------------------"
          cat $errFile >> $outFile
     else
          #   This merges stderr with stdout
-         mpirun -np ${SST_MULTI_RANK_COUNT} -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs} 2>${errFile}
+         mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs} 2>${errFile}
          RetVal=$?
          cat ${testOutFiles}* > $outFile
     fi

--- a/test/testSuites/testSuite_cacheTracer.sh
+++ b/test/testSuites/testSuite_cacheTracer.sh
@@ -80,7 +80,7 @@ test_cacheTracer_1() {
              cat $errFile >> $outFile
         else
              #   This merges stderr with stdout
-             mpirun -np ${SST_MULTI_RANK_COUNT} -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs} 2>${errFile}
+             mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs} 2>${errFile}
              RetVal=$?
              wc ${testOutFiles}*
              cat ${testOutFiles}* > $outFile

--- a/test/testSuites/testSuite_memHA.sh
+++ b/test/testSuites/testSuite_memHA.sh
@@ -83,7 +83,7 @@ Match=$2    ##  Match criteron
            ${sut} ${sutArgs} > ${outFile}
            RetVal=$? 
         else
-           mpirun -np ${SST_MULTI_RANK_COUNT} -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
+           mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
            RetVal=$? 
            cat ${testOutFiles}* > $outFile
            wc $outFile

--- a/test/testSuites/testSuite_memHierarchy_sdl.sh
+++ b/test/testSuites/testSuite_memHierarchy_sdl.sh
@@ -93,7 +93,7 @@ Tol=$2    ##  curTick tolerance
          grep -v 'not aligned to the request size' $errFile >> $outFile
     else
          #   This merges stderr with stdout
-         mpirun -np ${SST_MULTI_RANK_COUNT} -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs} 2>${errFile}
+         mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs} 2>${errFile}
          RetVal=$?
          cat ${testOutFiles}* > $outFile
          notAlignedCt=`grep -c 'not aligned to the request size' $outFile`

--- a/test/testSuites/testSuite_merlin.sh
+++ b/test/testSuites/testSuite_merlin.sh
@@ -72,7 +72,7 @@ Tol=$2    ##  curTick tolerance
            ${sut} ${sutArgs} > ${outFile}
            RetVal=$? 
         else
-           mpirun -np ${SST_MULTI_RANK_COUNT} -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
+           mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
            RetVal=$? 
            cat ${testOutFiles}* > $outFile
         fi

--- a/test/testSuites/testSuite_partitioner.sh
+++ b/test/testSuites/testSuite_partitioner.sh
@@ -185,7 +185,7 @@ PARTITIONER=$2
     if [ -f ${sut} ] && [ -x ${sut} ]
     then
         # Run SUT
-        mpirun -np ${NUMRANKS} ${sut} --verbose --partitioner $PARTITIONER --output-partition $partFile --model-options "--topo=torus --shape=4x4x4 --cmdLine=\"Init\" --cmdLine=\"Allreduce\" --cmdLine=\"Fini\"" ${sutArgs} > $outFile 2>$errFile
+        mpirun -np ${NUMRANKS} $NUMA_PARAM ${sut} --verbose --partitioner $PARTITIONER --output-partition $partFile --model-options "--topo=torus --shape=4x4x4 --cmdLine=\"Init\" --cmdLine=\"Allreduce\" --cmdLine=\"Fini\"" ${sutArgs} > $outFile 2>$errFile
         RetVal=$?
         TIME_FLAG=/tmp/TimeFlag_$$_${__timerChild} 
         if [ -e $TIME_FLAG ] ; then 

--- a/test/testSuites/testSuite_simpleComponent.sh
+++ b/test/testSuites/testSuite_simpleComponent.sh
@@ -75,7 +75,7 @@ test_simpleComponent() {
            ${sut} ${sutArgs} > ${outFile}
            RetVal=$? 
         else
-           mpirun -np ${SST_MULTI_RANK_COUNT} -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
+           mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
            RetVal=$? 
            cat ${testOutFiles}* > $outFile
         fi

--- a/test/testSuites/testSuite_simpleLookupTableComponent.sh
+++ b/test/testSuites/testSuite_simpleLookupTableComponent.sh
@@ -79,7 +79,7 @@ test_simpleLookupTableComponent() {
              cat $errFile >> $outFile
         else
              #   This merges stderr with stdout
-             mpirun -np ${SST_MULTI_RANK_COUNT} -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs} 2>${errFile}
+             mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs} 2>${errFile}
              RetVal=$?
              wc ${testOutFiles}*
              cat ${testOutFiles}* > $outFile

--- a/test/testSuites/testSuite_simpleSimulation_CarWash.sh
+++ b/test/testSuites/testSuite_simpleSimulation_CarWash.sh
@@ -75,7 +75,7 @@ test_simpleSimulation_CarWash() {
            ${sut} ${sutArgs} > ${outFile}
            RetVal=$? 
         else
-           mpirun -np ${SST_MULTI_RANK_COUNT} -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
+           mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles $NUMA_PARAM ${sut} ${sutArgs}
            RetVal=$? 
            cat ${testOutFiles}* > $outFile
         fi


### PR DESCRIPTION
This adds the map-by numa to 12 tests where it was previously over-looked
It also provides a third attempt at under what conditions to actually make the insertion.
The latter, inadvertently, skips the insertion on the zoltan and partitioner tests which were failing in the overnight on Yosemite and El Capitan Xcode8.