### PR TITLE
ReBalance the memH Sweep tests

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -527,7 +527,6 @@ echo " #####################################################"
             ${SST_TEST_SUITES}/testSuite_openMP.sh
             ${SST_TEST_SUITES}/testSuite_diropenMP.sh
             ${SST_TEST_SUITES}/testSuite_dirSweepB.sh
-            ${SST_TEST_SUITES}/testSuite_dirSweepI.sh
             ${SST_TEST_SUITES}/testSuite_dirSweep.sh
         fi
         if [ $GROUP == 1 ] ; then 
@@ -535,6 +534,7 @@ echo " #####################################################"
         fi
         ${SST_TEST_SUITES}/testSuite_dirnoncacheable_openMP.sh
         ${SST_TEST_SUITES}/testSuite_noncacheable_openMP.sh
+        ${SST_TEST_SUITES}/testSuite_dirSweepI.sh
         ${SST_TEST_SUITES}/testSuite_Sweep_openMP.sh
         ${SST_TEST_SUITES}/testSuite_dir3LevelSweep.sh
         return


### PR DESCRIPTION
The memH with Ariel Sweep Project is split into two parts run on alternate nights.    The recent enhancements to memHierarchy increased the run times for the Project such that one of the parts was taking 7 to 8 hours.   This moves one test Suite between parts to better balance the tests.   It may be necessary to further partition the tests.