### PR TITLE
Fix/tweak bamboo Multi processing

### DIFF
--- a/test/include/testDefinitions.sh
+++ b/test/include/testDefinitions.sh
@@ -235,7 +235,7 @@ fi
 #        but testSubroutines is loaded only in Suites.
 #           testDefinitions is loaded in bamboo.sh
 #
-#     Revised  October 30, 2015
+#     Revised  October 30, 2015, Sept. 27, 2017
 ######################################
 multithread_multirank_patch_Suites() {
     SET_TL=0
@@ -258,30 +258,30 @@ multithread_multirank_patch_Suites() {
             echo " There is a zero rank count, Set to 1 "
             export SST_MULTI_RANK_COUNT=1
         fi 
-        pushd test/testSuites
-        for fn in `ls testSuite_*.sh`
-        do
-           grep 'sut}.*sutArgs' $fn | grep mpirun 
-           if [ $? == 0 ] ; then
-             echo "Do not change $fn, it already has mpirun"
-             continue
-           fi
-           sed -i.x '/sut}.*sutArgs/s/..sut/mpirun -np '"${SST_MULTI_RANK_COUNT}"' $NUMA_PARAM ${sut/' $fn
-        done
-        popd
         if [ $SST_MULTI_RANK_COUNT -gt 1 ] ; then
-           SET_TL=1
+            pushd test/testSuites
+            for fn in `ls testSuite_*.sh`
+            do
+               grep 'sut}.*sutArgs' $fn | grep mpirun 
+               if [ $? == 0 ] ; then
+                 echo "Do not change $fn, it already has mpirun"
+                 continue
+               fi
+               sed -i.x '/sut}.*sutArgs/s/..sut/mpirun -np '"${SST_MULTI_RANK_COUNT}"' $NUMA_PARAM ${sut/' $fn
+            done
+            popd
+            SET_TL=1
         fi
     fi
 
     if [ $SET_TL == 1 ] ; then
-    echo "multithread_multirank_patch_Suites: ########### Patch the test Suites"
-    export SST_MULTI_CORE=1
-
-    sed -i.y '/Invoke shunit2/i \
-    export SST_TEST_ONE_TEST_TIMEOUT=200 \
-     ' test/testSuites/testSuite_*
-fi
+        echo "multithread_multirank_patch_Suites: ########### Patch the test Suites"
+        export SST_MULTI_CORE=1
+    
+        sed -i.y '/Invoke shunit2/i \
+        export SST_TEST_ONE_TEST_TIMEOUT=200 \
+         ' test/testSuites/testSuite_*
+    fi
 }
 
 set_map-by_parameter() {


### PR DESCRIPTION
Remove the feature of bamboo multi-rank processing that inserts a mpirun call even single rank is specified.