### PR TITLE
Add Support for any Boost and MPI versions 

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1540,6 +1540,9 @@ ldModules_MacOS_Clang() {
                                 echo "Boost 1.61 selected"
                                 ModuleEx add boost/boost-1.61.0-nompi_$ClangVersion
                                 ;;
+                            none)
+                                echo  "No BOOST loaded as requested"
+                                ;;
                             *)
                                 echo "bamboo.sh: \"Default\" Boost selected"
                                 echo "Third argument was $3"

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1519,9 +1519,9 @@ ldModules_MacOS_Clang() {
                                 echo  "No MPI loaded as requested"
                                 ;;
                             *)
-                                echo "Unrecognized MPI request"
-                                echo "Default MPI option, loading mpi/openmpi-1.8"
-                                ModuleEx load mpi/openmpi-1.8_$ClangVersion 2>catch.err
+                                echo "User Defined MPI request"
+                                echo "Default MPI option, loading users mpi/$2"
+                                ModuleEx load mpi/$2_$ClangVersion 2>catch.err
                                 if [ -s catch.err ] 
                                 then
                                     cat catch.err

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1544,8 +1544,8 @@ ldModules_MacOS_Clang() {
                                 echo  "No BOOST loaded as requested"
                                 ;;
                             *)
-                                echo "User Defined Boost request"
-                                echo "Boostoption, loading users boost/$3"
+                                echo "User Defined BOOST request"
+                                echo "BOOST option, loading users boost/$3"
                                 ModuleEx load boost/$3_$ClangVersion 2>catch.err
                                 if [ -s catch.err ] 
                                 then

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1520,7 +1520,7 @@ ldModules_MacOS_Clang() {
                                 ;;
                             *)
                                 echo "User Defined MPI request"
-                                echo "Default MPI option, loading users mpi/$2"
+                                echo "MPI option, loading users mpi/$2"
                                 ModuleEx load mpi/$2_$ClangVersion 2>catch.err
                                 if [ -s catch.err ] 
                                 then
@@ -1544,10 +1544,9 @@ ldModules_MacOS_Clang() {
                                 echo  "No BOOST loaded as requested"
                                 ;;
                             *)
-                                echo "bamboo.sh: \"Default\" Boost selected"
-                                echo "Third argument was $3"
-                                echo "Loading boost/Boost 1.56"
-                                ModuleEx load boost/boost-1.56.0-nompi_$ClangVersion 2>catch.err
+                                echo "User Defined Boost request"
+                                echo "Boostoption, loading users boost/$3"
+                                ModuleEx load boost/$3_$ClangVersion 2>catch.err
                                 if [ -s catch.err ] 
                                 then
                                     cat catch.err


### PR DESCRIPTION
This change will allow us to used any Boost or MPI version even if it is not the default.  Also added support for No Boost to be loaded.