### PR TITLE
Simple, uncomfortable fix for SZT multi-rank

### DIFF
--- a/test/testSuites/testSuite_SiriusZodiacTrace.sh
+++ b/test/testSuites/testSuite_SiriusZodiacTrace.sh
@@ -98,16 +98,9 @@ echo sutArgs
 echo $sutArgs
 echo "------------------------------"
 
-    if [[ ${SST_MULTI_RANK_COUNT:+isSet} != isSet ]] || [ ${SST_MULTI_RANK_COUNT} -lt 2 ] ; then
          ${sut} ${sutArgs} > ${outFile}  2>${errFile}
          RetVal=$? 
          cat $errFile >> $outFile
-    else
-         #   This merges stderr with stdout
-         mpirun -np ${SST_MULTI_RANK_COUNT} $NUMA_PARAM -output-filename $testOutFiles ${sut} ${sutArgs} 2>${errFile}
-         RetVal=$?
-         cat ${testOutFiles}* > $outFile
-    fi
 
         TIME_FLAG=$SSTTESTTEMPFILES/TimeFlag_$$_${__timerChild} 
         if [ -e $TIME_FLAG ] ; then 


### PR DESCRIPTION
Remove multi-rank specific code from sirius Zodiac testSuite.  It was previously required.  Now it's not acceptable.