### PR TITLE
Reverting PMIX ignore -- fixed on system

### DIFF
--- a/test/testSuites/testSuite_juno.sh
+++ b/test/testSuites/testSuite_juno.sh
@@ -55,8 +55,6 @@ echo '    ---  '
        return
    fi
 
-   cat $errFile | grep -v "PMIX" > $errFile
-
    if [ -s $errFile ] ; then
       cat $errFile
       fail " Non-empty Error File  $testname_case "


### PR DESCRIPTION
The PMIX bug has been fixed with the update to $TEMP. It should be safe to revert this change.