### PR TITLE
Build exit code

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1521,24 +1521,34 @@ dobuild() {
         "${SST_CORE_INSTALL}" \
         sst-core \
         autogen
+    retval=$?
+    if [ $retval -ne 0 ]; then exit $retval; fi
     config_and_build \
         sst-elements \
         "${SST_SELECTED_ELEMENTS_CONFIG}" \
         "${SST_CORE_INSTALL}" \
         "${SST_ROOT}/sst-elements" \
         autogen
+    retval=$?
+    if [ $retval -ne 0 ]; then exit $retval; fi
     config_and_build \
         sst-macro \
         "${SST_SELECTED_MACRO_CONFIG}" \
         "${SST_CORE_INSTALL}" \
         "${SST_ROOT}/sst-macro" \
         bootstrap
+    retval=$?
+    if [ $retval -ne 0 ]; then exit $retval; fi
     config_and_build_simple \
         sst-external-element \
         "${SST_SELECTED_EXTERNALELEMENT_CONFIG}"
+    retval=$?
+    if [ $retval -ne 0 ]; then exit $retval; fi
     config_and_build_simple \
         juno \
         "${SST_SELECTED_JUNO_CONFIG}"
+    retval=$?
+    if [ $retval -ne 0 ]; then exit $retval; fi
 }
 
 branch_to_commit_hash() {


### PR DESCRIPTION
For example, catch https://github.com/sstsimulator/sst-elements/pull/2275/commits/e1a6c71e6477a03ba50a8cc0c80b6e84b3fcd274 earlier.