### PR TITLE
Build exit code part 2

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -728,20 +728,22 @@ getconfig() {
 #   Return value:
 linuxSetMPI() {
 
-    # For some reason, .bashrc is not being run prior to
-    # this script. Kludge initialization of modules.
+   if [[ ${SST_STOP_AFTER_BUILD:+isSet} != isSet ]] ; then
+      # For some reason, .bashrc is not being run prior to
+      # this script. Kludge initialization of modules.
 
-    echo "Attempt to initialize the modules utility.  Look for modules init file in 1 of 2 places"
+      echo "Attempt to initialize the modules utility.  Look for modules init file in 1 of 2 places"
 
-    echo "Location 1: ls -l /etc/profile.modules"
-    echo "Location 2: ls -l /etc/profile.d/modules.sh"
-    if [ -r /etc/profile.modules ] ; then
-        source /etc/profile.modules
-        echo "bamboo.sh: loaded /etc/profile.modules"
-    elif [ -r /etc/profile.d/modules.sh ] ; then
-        source /etc/profile.d/modules.sh
-        echo "bamboo.sh: loaded /etc/profile.d/modules"
-    fi
+      echo "Location 1: ls -l /etc/profile.modules"
+      echo "Location 2: ls -l /etc/profile.d/modules.sh"
+      if [ -r /etc/profile.modules ] ; then
+          source /etc/profile.modules
+          echo "bamboo.sh: loaded /etc/profile.modules"
+      elif [ -r /etc/profile.d/modules.sh ] ; then
+          source /etc/profile.d/modules.sh
+          echo "bamboo.sh: loaded /etc/profile.d/modules"
+      fi
+   fi
 
    echo "Testing modules utility via ModuleEx..."
    echo "ModuleEx avail"
@@ -2025,12 +2027,14 @@ else
                 # Perform the build
                 dobuild -t $SST_BUILD_TYPE -a $arch -k $kernel
                 retval=$?
-                if [ $retval -eq 0 ] ; then
-                    echo "$0 : exit success."
-                else
-                    echo "$0 : exit failure."
+                if [[ ${SST_STOP_AFTER_BUILD:+isSet} == isSet ]] ; then
+                    if [ $retval -eq 0 ] ; then
+                        echo "$0 : exit success."
+                    else
+                        echo "$0 : exit failure."
+                    fi
+                    exit $retval
                 fi
-                exit $retval
             fi
 
             echo "PWD $LINENO = `pwd`"

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1558,6 +1558,8 @@ dobuild() {
         juno \
         "${SST_SELECTED_JUNO_CONFIG}"
     dobuild_handle_error $? juno
+
+    return 0
 }
 
 branch_to_commit_hash() {

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -728,22 +728,20 @@ getconfig() {
 #   Return value:
 linuxSetMPI() {
 
-   if [[ ${SST_STOP_AFTER_BUILD:+isSet} != isSet ]] ; then
-      # For some reason, .bashrc is not being run prior to
-      # this script. Kludge initialization of modules.
+    # For some reason, .bashrc is not being run prior to
+    # this script. Kludge initialization of modules.
 
-      echo "Attempt to initialize the modules utility.  Look for modules init file in 1 of 2 places"
+    echo "Attempt to initialize the modules utility.  Look for modules init file in 1 of 2 places"
 
-      echo "Location 1: ls -l /etc/profile.modules"
-      echo "Location 2: ls -l /etc/profile.d/modules.sh"
-      if [ -r /etc/profile.modules ] ; then
-          source /etc/profile.modules
-          echo "bamboo.sh: loaded /etc/profile.modules"
-      elif [ -r /etc/profile.d/modules.sh ] ; then
-          source /etc/profile.d/modules.sh
-          echo "bamboo.sh: loaded /etc/profile.d/modules"
-      fi
-   fi
+    echo "Location 1: ls -l /etc/profile.modules"
+    echo "Location 2: ls -l /etc/profile.d/modules.sh"
+    if [ -r /etc/profile.modules ] ; then
+        source /etc/profile.modules
+        echo "bamboo.sh: loaded /etc/profile.modules"
+    elif [ -r /etc/profile.d/modules.sh ] ; then
+        source /etc/profile.d/modules.sh
+        echo "bamboo.sh: loaded /etc/profile.d/modules"
+    fi
 
    echo "Testing modules utility via ModuleEx..."
    echo "ModuleEx avail"
@@ -2026,15 +2024,6 @@ else
             else
                 # Perform the build
                 dobuild -t $SST_BUILD_TYPE -a $arch -k $kernel
-                retval=$?
-                if [[ ${SST_STOP_AFTER_BUILD:+isSet} == isSet ]] ; then
-                    if [ $retval -eq 0 ] ; then
-                        echo "$0 : exit success."
-                    else
-                        echo "$0 : exit failure."
-                    fi
-                    exit $retval
-                fi
             fi
 
             echo "PWD $LINENO = `pwd`"

--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1365,6 +1365,8 @@ config_and_build() {
         echo "Current Working Dir = $(pwd)"
         ls -l
     fi
+
+    return 0
 }
 
 config_and_build_simple() {
@@ -1440,6 +1442,18 @@ config_and_build_simple() {
         popd
         echo "Current Working Dir = $(pwd)"
         ls -l
+    fi
+
+    return 0
+}
+
+dobuild_handle_error() {
+    local retval="${1}";
+    local project="${1}";
+
+    if [ "${retval}" -ne 0 ]; then
+        echo "Problem with ${project} project, exiting with code ${retval}" >&2
+        exit "${retval}";
     fi
 }
 
@@ -1521,34 +1535,29 @@ dobuild() {
         "${SST_CORE_INSTALL}" \
         sst-core \
         autogen
-    retval=$?
-    if [ $retval -ne 0 ]; then exit $retval; fi
+    dobuild_handle_error $? core
     config_and_build \
         sst-elements \
         "${SST_SELECTED_ELEMENTS_CONFIG}" \
         "${SST_CORE_INSTALL}" \
         "${SST_ROOT}/sst-elements" \
         autogen
-    retval=$?
-    if [ $retval -ne 0 ]; then exit $retval; fi
+    dobuild_handle_error $? elements
     config_and_build \
         sst-macro \
         "${SST_SELECTED_MACRO_CONFIG}" \
         "${SST_CORE_INSTALL}" \
         "${SST_ROOT}/sst-macro" \
         bootstrap
-    retval=$?
-    if [ $retval -ne 0 ]; then exit $retval; fi
+    dobuild_handle_error $? macro
     config_and_build_simple \
         sst-external-element \
         "${SST_SELECTED_EXTERNALELEMENT_CONFIG}"
-    retval=$?
-    if [ $retval -ne 0 ]; then exit $retval; fi
+    dobuild_handle_error $? external-element
     config_and_build_simple \
         juno \
         "${SST_SELECTED_JUNO_CONFIG}"
-    retval=$?
-    if [ $retval -ne 0 ]; then exit $retval; fi
+    dobuild_handle_error $? juno
 }
 
 branch_to_commit_hash() {


### PR DESCRIPTION
Follow-up of #1125 that fixes a misunderstanding of `if [[ ${SST_STOP_AFTER_BUILD:+isSet} == isSet ]] ; then`.