### PR TITLE
remove explicit parallelism in make calls

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1278,8 +1278,8 @@ config_and_build() {
         echo ' '
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
-        echo "=== Running make -j4 all ==="
-        make -j4 all
+        echo "=== Running make all ==="
+        make all
         retval=$?
         if [ $retval -ne 0 ]
         then
@@ -1299,8 +1299,8 @@ config_and_build() {
         echo ' '
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
-        echo "=== Running make -j4 install ==="
-        make -j4 install
+        echo "=== Running make install ==="
+        make install
         retval=$?
         if [ $retval -ne 0 ]
         then
@@ -1385,8 +1385,8 @@ config_and_build_simple() {
         echo ' '
         echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
-        echo "=== Running make -j4 ==="
-        make -j4
+        echo "=== Running make ==="
+        make
         retval=$?
         if [ $retval -ne 0 ]
         then
@@ -1406,8 +1406,8 @@ config_and_build_simple() {
         echo ' '
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
-        echo "=== Running make -j4 install ==="
-        make -j4 install
+        echo "=== Running make install ==="
+        make install
         retval=$?;
         if [ $retval -ne 0 ]
         then

--- a/buildsys/deps/bin/sstDep_dramsim3_stabledevel.sh
+++ b/buildsys/deps/bin/sstDep_dramsim3_stabledevel.sh
@@ -129,7 +129,7 @@ sstDepsDeploy_dramsim3 ()
         return $retval
     fi
 
-    make -j4
+    make
 
     retval=$?
     if [ $retval -ne 0 ]

--- a/test/testSuites/testSuite_macro.sh
+++ b/test/testSuites/testSuite_macro.sh
@@ -86,8 +86,7 @@ test_macro_make_check() {
     then
         # Run SUT
 #        (make ${sutArgs} > $outFile)
-        # TODO parameterize number of build threads
-        (make -j4 ${sutArgs})
+        (make ${sutArgs})
         RetVal=$?
         local TIME_FLAG=$SSTTESTTEMPFILES/TimeFlag_$$_${__timerChild}
         if [ -e $TIME_FLAG ] ; then
@@ -149,8 +148,7 @@ test_macro_make_installcheck() {
     then
         # Run SUT
 #        (make ${sutArgs} > $outFile)
-        # TODO parameterize number of build threads
-        (make -j4 ${sutArgs})
+        (make ${sutArgs})
         RetVal=$?
         local TIME_FLAG=$SSTTESTTEMPFILES/TimeFlag_$$_${__timerChild}
         if [ -e $TIME_FLAG ] ; then


### PR DESCRIPTION
Callers should set `export MAKEFLAGS="-j4"` or `export MAKEFLAGS="-j$(nproc)"` instead.

Cannot be merged until the Jenkins jobs add this.