### PR TITLE
Revert "remove explicit parallelism in make calls"

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -1278,8 +1278,8 @@ config_and_build() {
         echo ' '
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
-        echo "=== Running make all ==="
-        make all
+        echo "=== Running make -j4 all ==="
+        make -j4 all
         retval=$?
         if [ $retval -ne 0 ]
         then
@@ -1299,8 +1299,8 @@ config_and_build() {
         echo ' '
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
-        echo "=== Running make install ==="
-        make install
+        echo "=== Running make -j4 install ==="
+        make -j4 install
         retval=$?
         if [ $retval -ne 0 ]
         then
@@ -1385,8 +1385,8 @@ config_and_build_simple() {
         echo ' '
         echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
-        echo "=== Running make ==="
-        make
+        echo "=== Running make -j4 ==="
+        make -j4
         retval=$?
         if [ $retval -ne 0 ]
         then
@@ -1406,8 +1406,8 @@ config_and_build_simple() {
         echo ' '
         echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
-        echo "=== Running make install ==="
-        make install
+        echo "=== Running make -j4 install ==="
+        make -j4 install
         retval=$?;
         if [ $retval -ne 0 ]
         then

--- a/buildsys/deps/bin/sstDep_dramsim3_stabledevel.sh
+++ b/buildsys/deps/bin/sstDep_dramsim3_stabledevel.sh
@@ -129,7 +129,7 @@ sstDepsDeploy_dramsim3 ()
         return $retval
     fi
 
-    make
+    make -j4
 
     retval=$?
     if [ $retval -ne 0 ]

--- a/test/testSuites/testSuite_macro.sh
+++ b/test/testSuites/testSuite_macro.sh
@@ -86,7 +86,8 @@ test_macro_make_check() {
     then
         # Run SUT
 #        (make ${sutArgs} > $outFile)
-        (make ${sutArgs})
+        # TODO parameterize number of build threads
+        (make -j4 ${sutArgs})
         RetVal=$?
         local TIME_FLAG=$SSTTESTTEMPFILES/TimeFlag_$$_${__timerChild}
         if [ -e $TIME_FLAG ] ; then
@@ -148,7 +149,8 @@ test_macro_make_installcheck() {
     then
         # Run SUT
 #        (make ${sutArgs} > $outFile)
-        (make ${sutArgs})
+        # TODO parameterize number of build threads
+        (make -j4 ${sutArgs})
         RetVal=$?
         local TIME_FLAG=$SSTTESTTEMPFILES/TimeFlag_$$_${__timerChild}
         if [ -e $TIME_FLAG ] ; then


### PR DESCRIPTION
Reverts sstsimulator/sst-sqe#1137

There is something in https://github.com/tactcomplabs/gc64-hmcsim that is not robust to changing the build parallelism, but only in the context of building other things.  Checking out a copy at the `sst-8.0.0-release` tag and doing `export MAKEFLAGS=-j4; make` works fine.