### PR TITLE
Set CCACHE_BASEDIR

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -790,6 +790,7 @@ linuxSetMPI() {
    if ModuleEx load ccache/ccache-4.12; then
        echo "ccache successfully loaded"
        export CCACHE_MAXSIZE=10G
+       export CCACHE_BASEDIR=/ascldap/users/sstbuilder/jenkins/workspace
    fi
 
    # load MPI


### PR DESCRIPTION
This should make ccache actually hit.  Currently it misses because there is a timestamp embedded in the workspace path.