### PR TITLE
export CCACHE_NOHASHDIR

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -790,6 +790,7 @@ linuxSetMPI() {
    if ModuleEx load ccache/ccache-4.12; then
        echo "ccache successfully loaded"
        export CCACHE_MAXSIZE=10G
+       export CCACHE_NOHASHDIR
        export CCACHE_BASEDIR=/ascldap/users/sstbuilder/jenkins/workspace
    fi
 


### PR DESCRIPTION
https://ccache.dev/manual/4.12.2.html#_compiling_in_different_directories

The link above directs users to set hash_dir = false in addition to configuring base_dir.