### PR TITLE
Add wrapper for running bamboo locally

### DIFF
--- a/.github/scripts/call_bamboo.sh
+++ b/.github/scripts/call_bamboo.sh
@@ -3,10 +3,36 @@
 # call_bamboo.sh: wrapper for calling bamboo.sh inside of a GitHub Action
 # workflow.
 
-set -euo pipefail
+set -eo pipefail
+
+if [[ -z "${SST_DEPS_USER_DIR}" ]]; then
+    echo "SST_DEPS_USER_DIR not defined"
+    return 1
+fi
+if [[ -z "${GITHUB_WORKSPACE}" ]]; then
+    echo "GITHUB_WORKSPACE not defined"
+    return 1
+fi
+if [[ -z "${BUILD_TYPE}" ]]; then
+    echo "BUILD_TYPE not defined"
+    return 1
+fi
+if [[ -z "${MPI_TYPE}" ]]; then
+    echo "MPI_TYPE not defined"
+    return 1
+fi
+if [[ -z "${COMPILER_TYPE}" ]]; then
+    echo "COMPILER_TYPE not defined"
+    return 1
+fi
+if [[ -z "${CUDA_TYPE}" ]]; then
+    CUDA_TYPE=none
+fi
 
 # needed for ncurses part of interactive sst-info
-export TERM=dumb
+if [[ -z "${TERM}" ]]; then
+    export TERM=dumb
+fi
 MAKEFLAGS="-j$(nproc)"
 export MAKEFLAGS
 if [[ "$(uname)" == "Darwin" ]]; then
@@ -38,5 +64,5 @@ fi
     "${MPI_TYPE}" \
     none \
     "${COMPILER_TYPE}" \
-    none \
+    "${CUDA_TYPE}" \
     none

--- a/.github/scripts/call_bamboo.sh
+++ b/.github/scripts/call_bamboo.sh
@@ -30,9 +30,8 @@ if [[ -z "${CUDA_TYPE}" ]]; then
 fi
 
 # needed for ncurses part of interactive sst-info
-if [[ -z "${TERM}" ]]; then
-    export TERM=dumb
-fi
+echo "TERM: ${TERM}"
+export TERM=dumb
 MAKEFLAGS="-j$(nproc)"
 export MAKEFLAGS
 if [[ "$(uname)" == "Darwin" ]]; then

--- a/dev/run-bamboo-like-github.sh
+++ b/dev/run-bamboo-like-github.sh
@@ -26,9 +26,8 @@ GITHUB_WORKSPACE_PRE="${tmpdir}/home/runner/work/sst-sqe"
 mkdir -p "${GITHUB_WORKSPACE_PRE}"
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cp -a "${SCRIPTDIR}" "${GITHUB_WORKSPACE_PRE}"
-# TODO this assumes that the clone of this repo (the directory this script is
-# in) is called "sst-sqe".
-export GITHUB_WORKSPACE="${GITHUB_WORKSPACE_PRE}"/sst-sqe
+clone_name="$(basename "${SCRIPTDIR}")"
+export GITHUB_WORKSPACE="${GITHUB_WORKSPACE_PRE}"/"${clone_name}"
 pushd "${GITHUB_WORKSPACE}"
 
 # "set env and prepare dir structure"

--- a/dev/run-bamboo-like-github.sh
+++ b/dev/run-bamboo-like-github.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# run-bamboo-like-github.sh: Just like it says on the tin.  Runs
+# call_bamboo.sh in a way as close as possible to the GitHub Actions workflow.
+# Bamboo command-line args are hardcoded in this file for convenience.
+
+set -euo pipefail
+
+if [[ -t 1 ]]; then
+    echo "stdout is interactive but must be redirected for this script to run properly"
+    return 1
+fi
+if [[ -t 2 ]]; then
+    echo "stderr is interactive but must be redirected for this script to run properly"
+    return 1
+fi
+
+export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
+tmpdir="$(mktemp --directory)"
+echo "tmpdir: ${tmpdir}"
+
+# GITHUB_WORKSPACE is /home/runner/work/sst-sqe/sst-sqe which is the location
+# of this repo.
+GITHUB_WORKSPACE_PRE="${tmpdir}/home/runner/work/sst-sqe"
+mkdir -p "${GITHUB_WORKSPACE_PRE}"
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cp -a "${SCRIPTDIR}" "${GITHUB_WORKSPACE_PRE}"
+# TODO this assumes that the clone of this repo (the directory this script is
+# in) is called "sst-sqe".
+export GITHUB_WORKSPACE="${GITHUB_WORKSPACE_PRE}"/sst-sqe
+pushd "${GITHUB_WORKSPACE}"
+
+# "set env and prepare dir structure"
+# In GH, /home/runner/work/sst-sqe/sst-deps-user-dir
+sst_deps_user_dir="${GITHUB_WORKSPACE}/../sst-deps-user-dir"
+mkdir -p "${sst_deps_user_dir}"
+SST_DEPS_USER_DIR="$(realpath "${sst_deps_user_dir}")"
+export SST_DEPS_USER_DIR
+
+# "fetch elements dependencies"
+pristine="${SST_DEPS_USER_DIR}"/sstDeps/src/pristine
+mkdir -p "${pristine}"
+pushd "${pristine}"
+wget --no-verbose https://github.com/umd-memsys/DRAMSim2/archive/refs/tags/v2.2.2.tar.gz
+popd
+
+# "run bamboo"
+#
+# sstmainline_config | sstmainline_coreonly_config |
+# sstmainline_coreonly_config_no_mpi | ...
+# export BUILD_TYPE=sstmainline_config_with_pebil
+# export MPI_TYPE=mpi/openmpi-4.1.6_gcc-8.5.0
+# export COMPILER_TYPE=none
+
+unset BUILD_TYPE
+unset MPI_TYPE
+unset COMPILER_TYPE
+unset CUDA_TYPE
+
+export BUILD_TYPE=sstmainline_config_linux_with_cuda
+export MPI_TYPE=openmpi-4.1.4
+export COMPILER_TYPE=gcc-11.5.0
+export CUDA_TYPE=aue/cuda/11.8.0-gcc-10.3.0
+
+bash ./.github/scripts/call_bamboo.sh


### PR DESCRIPTION
This makes it easier to run bamboo locally.  It actually calls `.github/scripts/call_bamboo.sh`, which itself calls `buildsys/bamboo.sh`.  The reason is that the script used as part of the GitHub Actions workflow emulates how it is done in Jenkins a bit closer than just calling `bamboo.sh` regarding the predefined environment variables, so it already does some required work for us.