### PR TITLE
Capture compiler phase to ccache

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -792,6 +792,9 @@ linuxSetMPI() {
        export CCACHE_MAXSIZE=10G
        export CCACHE_NOHASHDIR
        export CCACHE_BASEDIR=/ascldap/users/sstbuilder/jenkins/workspace
+       # specify OMPI compiler wrappers so we caputure the build for ccache
+       export OMPI_CC=gcc
+       export OMPI_CXX=g++
    fi
 
    # load MPI


### PR DESCRIPTION
By adding the `OMPI_CC` / `OMPI_CXX` environment variables after ccache is loaded, we can then intercept all of the calls to `mpicc` / `mpicxx` (which is most of them).
