### PR TITLE
Disable ccache direct mode

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -791,6 +791,7 @@ linuxSetMPI() {
        echo "ccache successfully loaded"
        export CCACHE_MAXSIZE=10G
        export CCACHE_NOHASHDIR
+       export CCACHE_NODIRECT
        # specify OMPI compiler wrappers so we caputure the build for ccache
        export OMPI_CC=gcc
        export OMPI_CXX=g++


### PR DESCRIPTION
This will force us into [preprocessor mode](https://ccache.dev/manual/4.12.2.html#_the_preprocessor_mode)

Preprocessor mode does not consider -I flags so our large directories (which include the current date and time) should not impact the hit rate.