### PR TITLE
Retry stalled git clones and right-size clone timeouts

### DIFF
--- a/buildsys/bamboo.sh
+++ b/buildsys/bamboo.sh
@@ -50,13 +50,28 @@ cloneRepo() {
     local commit_hash
     commit_hash="${!commit_hash_varname}"
 
-    echo " "
-    echo "     TimeoutEx -t ${timeout} git clone ${repo} ${clone_loc}"
-    date
-    TimeoutEx -t "${timeout}" git clone "${repo}" "${clone_loc}"
-    retVal=$?
+    # Clones occasionally stall mid-transfer on hosted runners, so retry a
+    # couple of times before failing the whole run.
+    local attempt
+    local max_clone_attempts=3
+    for attempt in $(seq 1 ${max_clone_attempts}); do
+        echo " "
+        echo "     TimeoutEx -t ${timeout} git clone ${repo} ${clone_loc} (attempt ${attempt} of ${max_clone_attempts})"
+        date
+        TimeoutEx -t "${timeout}" git clone "${repo}" "${clone_loc}"
+        retVal=$?
+        if [ $retVal -eq 0 ]; then
+            break
+        fi
+        echo "\"git clone ${repo} ${clone_loc}\" FAILED on attempt ${attempt}; retVal = ${retVal}"
+        # a timed-out clone leaves a partial checkout behind
+        rm -rf "${clone_loc}"
+        if [ $attempt -lt $max_clone_attempts ]; then
+            sleep 30
+        fi
+    done
     if [ $retVal -ne 0 ]; then
-        echo "\"git clone ${repo} ${clone_loc}\" FAILED."
+        echo "\"git clone ${repo} ${clone_loc}\" FAILED after ${max_clone_attempts} attempts."
         exit 1
     fi
     date
@@ -131,14 +146,14 @@ cloneOtherRepos() {
             "${SST_ELEMENTSBRANCH}" \
             devel \
             sst-elements \
-            250
+            600
         cloneRepo \
             "${SST_MACROREPO}" \
             SST_MACRO_HASH \
             "${SST_MACROBRANCH}" \
             devel \
             sst-macro \
-            90
+            300
         cloneRepo \
             "${SST_EXTERNALELEMENTREPO}" \
             SST_EXTERNALELEMENT_HASH \


### PR DESCRIPTION
## Problem

CI runs intermittently die when a repository clone stalls mid-transfer:

```
ERROR: Timeout after 250 seconds waiting for command "git clone https://github.com/sstsimulator/sst-elements sst-elements"
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
```

`cloneRepo()` makes a single attempt and `exit 1`s the entire (hour-plus) run on any failure.

Timeouts have little to no headroom on macOS runners:

| Clone | Budget | Linux actual | macOS actual |
|---|---|---|---|
| sst-core | 90s | 3s | 23s |
| sst-elements | 250s | 12s | **~220s** |
| sst-macro | 90s | 5s | **~90s+** |

The sst-macro clone on macOS routinely takes about the entire 90s budget, so every macOS run is a coin flip at that step.

## Fix

1. **Retry the clone up to 3 times**, removing the partial checkout between attempts, with a 30s pause between tries. A transient stall no longer kills the whole run.
2. **Raise timeouts based on the measured data**: sst-elements 250s → 600s, sst-macro 90s → 300s. Linux clones these repos in seconds, so the larger budgets only matter when a transfer is already degraded.

Clones intentionally remain full (non-shallow): `cloneRepo()` later runs `git reset --hard <hash>` and optionally merges `upstream/devel`, both of which need real history.

## Testing

- `bash -n` syntax check.
- Retry-loop semantics verified with a stubbed `TimeoutEx` (success first try, recovery after 1–2 failures, hard fail after 3).
- Cherry-picked onto a feature branch whose CI previously hit both failure modes; runs green.